### PR TITLE
feat: move mnemonic entry to its own component

### DIFF
--- a/src/components/MnemonicEntry.tsx
+++ b/src/components/MnemonicEntry.tsx
@@ -1,0 +1,82 @@
+import React, { useState, ClipboardEvent, ChangeEvent, useEffect } from "react";
+import clsx from "clsx";
+
+interface MnemonicEntryProps {
+  seedPhraseLength: number;
+  mnemonicRef: React.RefObject<HTMLTextAreaElement | null>;
+}
+
+export const MnemonicEntry = ({
+  seedPhraseLength,
+  mnemonicRef,
+}: MnemonicEntryProps) => {
+  const [focusedIndex, setFocusedIndex] = useState<number | null>(null);
+
+  // If the user changes the seed phrase length, reset the input fields
+  useEffect(() => {
+    if (mnemonicRef.current) mnemonicRef.current.value = "";
+    document
+      .querySelectorAll<HTMLInputElement>(".mnemonic-input-grid input")
+      .forEach((i) => (i.value = ""));
+    setFocusedIndex(null);
+  }, [seedPhraseLength]);
+
+  const handlePaste = (e: ClipboardEvent<HTMLInputElement>, idx: number) => {
+    if (idx !== 0) return;
+    e.preventDefault();
+    const pastedText = e.clipboardData.getData("text");
+    const words = pastedText.trim().split(/\s+/).slice(0, seedPhraseLength);
+
+    const inputs = Array.from(
+      (e.target as HTMLInputElement).parentElement
+        ?.querySelectorAll("input") ?? []
+    ) as HTMLInputElement[];
+
+    words.forEach((word, i) => {
+      if (inputs[i]) inputs[i].value = word;
+    });
+    if (mnemonicRef.current) mnemonicRef.current.value = words.join(" ");
+  };
+
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const inputEl = e.target as HTMLInputElement;
+    const allInputs =
+      inputEl.parentElement?.querySelectorAll("input") ?? [];
+    const words = Array.from(allInputs).map(
+      (inp) => (inp as HTMLInputElement).value
+    );
+    if (mnemonicRef.current) mnemonicRef.current.value = words.join(" ");
+  };
+
+  return (
+    <div>
+      <label className="block mb-1 font-medium text-[var(--text-primary)]">
+        Mnemonic Phrase
+      </label>
+      <div className="mnemonic-input-grid grid grid-cols-3 md:grid-cols-6 gap-2 mb-2">
+        {Array.from({ length: seedPhraseLength }, (_, i) => {
+          const visible = focusedIndex === i;
+          return (
+            <input
+              key={i}
+              type={visible ? "text" : "password"}
+              placeholder={`Word ${i + 1}`}
+              className={clsx(
+                "w-full p-2 rounded",
+                "bg-[var(--primary-bg)] border border-[var(--border-color)]",
+                "text-[var(--text-primary)]",
+                "focus:outline-none focus:border-[var(--accent-blue)]",
+                "placeholder:text-sm"
+              )}
+              onFocus={() => setFocusedIndex(i)}
+              onBlur={() => setFocusedIndex(null)}
+              onPaste={(e) => handlePaste(e, i)}
+              onChange={handleChange}
+            />
+          );
+        })}
+      </div>
+      <textarea ref={mnemonicRef} readOnly className="hidden" />
+    </div>
+  );
+};

--- a/src/containers/WalletGuard.css
+++ b/src/containers/WalletGuard.css
@@ -257,13 +257,6 @@
   align-items: center;
 }
 
-.mnemonic-input-grid {
-  display: grid;
-  grid-template-columns: repeat(6, 1fr);
-  gap: 10px;
-  margin-bottom: 15px;
-}
-
 .mnemonic-word-input {
   width: 100%;
   padding: 8px;
@@ -512,9 +505,5 @@
   
   .radio-option {
     padding: 0.5rem;
-  }
-  
-  .mnemonic-input-grid {
-    grid-template-columns: repeat(3, 1fr);
   }
 } 

--- a/src/containers/WalletGuard.tsx
+++ b/src/containers/WalletGuard.tsx
@@ -5,6 +5,7 @@ import "./WalletGuard.css";
 import { NetworkSelector } from "./NetworkSelector";
 import { NetworkType } from "../types/all";
 import { Wallet, WalletDerivationType } from "src/types/wallet.type";
+import {MnemonicEntry} from "../components/MnemonicEntry";
 
 const PASSWORD_MIN_LENGTH = 4; // Minimum password length
 
@@ -34,9 +35,6 @@ export const WalletGuard = ({
   const [seedPhraseLength, setSeedPhraseLength] = useState<12 | 24>(24); // Default to 24 words
   const [derivationType, setDerivationType] =
     useState<WalletDerivationType>("standard"); // Default to standard
-  const [focusedMnemonicIndex, setFocusedMnemonicIndex] = useState<
-    number | null
-  >(null);
   const passwordRef = useRef<HTMLInputElement>(null);
   const mnemonicRef = useRef<HTMLTextAreaElement>(null);
   const nameRef = useRef<HTMLInputElement>(null);
@@ -383,60 +381,10 @@ export const WalletGuard = ({
                 <span>24 words</span>
               </label>
             </div>
-
-            <label>Mnemonic Phrase</label>
-            <div className="mnemonic-input-grid">
-              {Array.from({ length: seedPhraseLength }, (_, i) => (
-                <input
-                  key={i}
-                  type={focusedMnemonicIndex === i ? "text" : "password"}
-                  placeholder={`Word ${i + 1}`}
-                  className="mnemonic-word-input"
-                  data-index={i}
-                  onFocus={() => setFocusedMnemonicIndex(i)}
-                  onBlur={() => setFocusedMnemonicIndex(null)}
-                  onPaste={(e) => {
-                    if (i === 0) {
-                      e.preventDefault();
-                      const pastedText = e.clipboardData.getData("text");
-                      const words = pastedText.trim().split(/\s+/);
-
-                      const inputElement = e.target as HTMLInputElement;
-                      const allInputs =
-                        inputElement.parentElement?.querySelectorAll("input");
-                      if (!allInputs) return;
-
-                      words
-                        .slice(0, seedPhraseLength)
-                        .forEach((word, index) => {
-                          if (allInputs[index]) {
-                            (allInputs[index] as HTMLInputElement).value = word;
-                          }
-                        });
-
-                      if (mnemonicRef.current) {
-                        mnemonicRef.current.value = words
-                          .slice(0, seedPhraseLength)
-                          .join(" ");
-                      }
-                    }
-                  }}
-                  onChange={(e) => {
-                    const inputElement = e.target as HTMLInputElement;
-                    const allInputs =
-                      inputElement.parentElement?.querySelectorAll("input") ||
-                      [];
-                    const words = Array.from(allInputs)
-                      .map((input) => input.value)
-                      .join(" ");
-                    if (mnemonicRef.current) {
-                      mnemonicRef.current.value = words;
-                    }
-                  }}
-                />
-              ))}
-            </div>
-            <textarea ref={mnemonicRef} style={{ display: "none" }} />
+            <MnemonicEntry
+              seedPhraseLength={seedPhraseLength}
+              mnemonicRef={mnemonicRef}
+            />
           </div>
         )}
 


### PR DESCRIPTION
## What?
This PR modifies the Mnemonic Entry section of `WalletGuard`. 

PR does the following:
- move mnemoinc entry to its own component
- clear entry when user changes between seed word length
- restyle in tailwind
- delete css that's now not needed
- refactor functions

_Originally I did this so I could work on 'masking' the input length when the word fields are hidden. But, that can come later on down the track._

## Test?
Make sure importing seeds still words the same. I checked it and its fine, but you should too.