### PR TITLE
Feat/mobile tweaks

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,13 @@
-import React, { useCallback } from 'react'
+import React, { useCallback, useEffect } from 'react'
 import { useNetworkStore } from './store/network.store'
 import type { NetworkType } from './types/all'
 import { AppRoutes } from './AppRoutes';
+import { useIsMobile } from './utils/useIsMobile';
 
 const App: React.FC = () => {
   const networkStore = useNetworkStore();
   const connect = useNetworkStore((s) => s.connect);
+  const isMobile = useIsMobile();
 
   const onNetworkChange = useCallback(
     (n: NetworkType) => {
@@ -14,6 +16,16 @@ const App: React.FC = () => {
     },
     [connect, networkStore]
   );
+
+  useEffect(() => {
+    const meta = document.querySelector<HTMLMetaElement>(
+      'meta[name="viewport"]'
+    );
+    if (!meta) return;
+    meta.content = isMobile
+      ? "width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
+      : "width=device-width, initial-scale=1.0";
+  }, [isMobile]);
 
   return (
     <AppRoutes

--- a/src/OneLiner.tsx
+++ b/src/OneLiner.tsx
@@ -152,14 +152,14 @@ export const OneLiner: FC = () => {
   return (
     <>
       {/* Main Message Section*/}
-      <div className="px-1 sm:px-8 py-4 bg-[var(--primary-bg)]">
+      <div className="sm:px-8 sm:py-4 bg-[var(--primary-bg)]">
         <div className="flex items-center gap-4">
           {isWalletReady &&
             (isWalletReady && messageStore.isLoaded ? (
               <div
                 className="
               bg-[var(--secondary-bg)] rounded-xl shadow-md sm:max-w-[1200px] w-full sm:mx-auto
-              border border-[var(--border-color)] overflow-hidden min-w-[320px] h-[95vh] sm:h-[85vh] min-h-[300px]
+              border border-[var(--border-color)] overflow-hidden min-w-[320px] h-[100vh] sm:h-[85vh] min-h-[300px]
               flex
             "
               >
@@ -182,7 +182,7 @@ export const OneLiner: FC = () => {
             ) : (
               <div className="flex flex-col items-center w-full text-xs">
                 {/* If wallet is unlocked but message are not loaded, show the loading state*/}
-                <div className="relative sm:max-w-[1200px] w-full mx-auto min-w-[320px] h-[95vh] sm:h-[85vh]  min-h-[300px] overflow-hidden rounded-xl border border-[var(--border-color)] shadow-md">
+                <div className="relative sm:max-w-[1200px] w-full mx-auto min-w-[320px] h-[100vh] sm:h-[85vh]  min-h-[300px] overflow-hidden rounded-xl border border-[var(--border-color)] shadow-md">
                   <div className="absolute inset-0 bg-[var(--secondary-bg)]/20 animate-pulse" />
                   <div className="relative flex flex-col items-center justify-center h-full space-y-4">
                     <span className="text-sm sm:text-lg text-gray-300 font-medium tracking-wide">

--- a/src/containers/WalletGuard.css
+++ b/src/containers/WalletGuard.css
@@ -202,7 +202,7 @@
   font-size: 12px;
 }
 
-.selected-wallet-info {
+/* .selected-wallet-info {
   text-align: center;
   margin-bottom: 20px;
   padding: 10px;
@@ -213,7 +213,7 @@
 .selected-wallet-info .wallet-name {
   font-weight: 600;
   color: var(--text-primary);
-}
+} */
 
 .radio-option {
   display: flex;

--- a/src/containers/WalletGuard.tsx
+++ b/src/containers/WalletGuard.tsx
@@ -348,16 +348,16 @@ export const WalletGuard = ({
             ))}
           </div>
 
-          <div className="flex flex-col gap-2 justify-center sm:flex-row">
+          <div className="flex flex-col gap-2 justify-center sm:flex-row-reverse sm:gap-4">
             <button
               onClick={() => onStepChange("create")}
-              className="w-full sm:w-auto bg-[var(--accent-blue)] text-white font-bold py-3 px-4 sm:px-6 rounded-lg transition-colors duration-200"
+              className="cursor-pointer w-full bg-[var(--accent-blue)] text-white font-bold py-3 px-4 sm:px-6 rounded-lg transition-colors duration-200"
             >
               Create New Wallet
             </button>
             <button
               onClick={() => onStepChange("import")}
-              className="w-full sm:w-auto bg-[var(--accent-blue)] text-white font-bold py-3 px-4 sm:px-6 rounded-lg transition-colors duration-200"
+              className="cursor-pointer w-full bg-[var(--accent-blue)] text-white font-bold py-3 px-4 sm:px-6 rounded-lg transition-colors duration-200"
             >
               Import Wallet
             </button>
@@ -449,9 +449,19 @@ export const WalletGuard = ({
 
           {error && <div className="error">{error}</div>}
 
-          <div className="form-actions">
-            <button onClick={() => onStepChange("home")}>Back</button>
-            <button onClick={onCreateWallet}>Create</button>
+          <div className="flex flex-col gap-2 justify-center sm:flex-row-reverse sm:gap-4">
+            <button
+              onClick={onCreateWallet}
+              className="cursor-pointer w-full bg-[var(--accent-blue)] text-white font-bold py-3 px-4 sm:px-6 rounded-lg transition-colors duration-200"
+            >
+              Create
+            </button>
+            <button
+              onClick={() => onStepChange("home")}
+              className="cursor-pointer w-full bg-[var(--primary-bg)] text-white font-bold py-3 px-4 sm:px-6 rounded-lg transition-colors duration-200"
+            >
+              Back
+            </button>
           </div>
         </>
       )}
@@ -603,9 +613,19 @@ export const WalletGuard = ({
 
           {error && <div className="error">{error}</div>}
 
-          <div className="form-actions">
-            <button onClick={() => onStepChange("home")}>Back</button>
-            <button onClick={onImportWallet}>Import</button>
+          <div className="flex flex-col gap-2 justify-center sm:flex-row-reverse sm:gap-4">
+            <button
+              onClick={onImportWallet}
+              className="cursor-pointer w-full bg-[var(--accent-blue)] text-white font-bold py-3 px-4 sm:px-6 rounded-lg transition-colors duration-200"
+            >
+              Create
+            </button>
+            <button
+              onClick={() => onStepChange("home")}
+              className="cursor-pointer w-full bg-[var(--primary-bg)] text-white font-bold py-3 px-4 sm:px-6 rounded-lg transition-colors duration-200"
+            >
+              Back
+            </button>
           </div>
         </>
       )}
@@ -616,7 +636,7 @@ export const WalletGuard = ({
           <h2 className="font-bold text-lg text-center">Wallet Unlocked</h2>
           <div className="mt-5 flex justify-center">
             <button
-              className="bg-[var(--accent-blue)] hover:bg-[var(--accent-blue)]/90 text-white text-sm font-bold py-2 px-4 rounded cursor-pointer"
+              className="w-full bg-[var(--accent-blue)] hover:bg-[var(--accent-blue)]/90 text-white text-sm font-bold py-2 px-4 rounded cursor-pointer"
               onClick={() => onStepChange("home")}
             >
               Back to Wallets
@@ -643,9 +663,10 @@ export const WalletGuard = ({
               path (m/44'/111111'/0') that is compatible with Kaspium and other
               standard wallets.
             </p>
-            <div className="my-5 p-4 bg-[#1a1f2e] border border-[#2a3042] rounded-lg flex flex-col items-center">
-              ⚠️ Your original wallet will remain unchanged. You'll need to
-              transfer funds to the new wallet addresses.
+            <div className="my-5 text-amber-300 p-4 text-center bg-[#1a1f2e] border border-[#2a3042] rounded-lg flex flex-col items-center">
+              <ExclamationTriangleIcon className="w-5 h-5" /> Your original
+              wallet will remain unchanged. You'll need to transfer funds to the
+              new wallet addresses.
             </div>
           </div>
 
@@ -674,9 +695,19 @@ export const WalletGuard = ({
 
           {error && <div className="error">{error}</div>}
 
-          <div className="form-actions">
-            <button onClick={() => onStepChange("home")}>Cancel</button>
-            <button onClick={onMigrateWallet}>Migrate Wallet</button>
+          <div className="flex flex-col gap-2 justify-center sm:flex-row-reverse sm:gap-4">
+            <button
+              onClick={onMigrateWallet}
+              className="cursor-pointer w-full bg-[var(--accent-blue)] text-white font-bold py-3 px-4 sm:px-6 rounded-lg transition-colors duration-200"
+            >
+              Create
+            </button>
+            <button
+              onClick={() => onStepChange("home")}
+              className="cursor-pointer w-full bg-[var(--primary-bg)] text-white font-bold py-3 px-4 sm:px-6 rounded-lg transition-colors duration-200"
+            >
+              Back
+            </button>
           </div>
         </>
       )}
@@ -710,10 +741,19 @@ export const WalletGuard = ({
           </div>
 
           {error && <div className="error">{error}</div>}
-
-          <div className="form-actions">
-            <button onClick={() => onStepChange("home")}>Back</button>
-            <button onClick={onUnlockWallet}>Unlock</button>
+          <div className="flex flex-col gap-2 justify-center sm:flex-row-reverse sm:gap-4">
+            <button
+              onClick={onUnlockWallet}
+              className="cursor-pointer w-full bg-[var(--accent-blue)] text-white font-bold py-3 px-4 sm:px-6 rounded-lg transition-colors duration-200"
+            >
+              Unlock
+            </button>
+            <button
+              onClick={() => onStepChange("home")}
+              className="cursor-pointer w-full bg-[var(--primary-bg)] text-white font-bold py-3 px-4 sm:px-6 rounded-lg transition-colors duration-200"
+            >
+              Back
+            </button>
           </div>
         </>
       )}

--- a/src/containers/WalletGuard.tsx
+++ b/src/containers/WalletGuard.tsx
@@ -277,7 +277,7 @@ export const WalletGuard = ({
   
 
   const wrapperClass =
-  clsx("sm:max-w-[600px] w-full mx-auto my-8 p-8 bg-[var(--secondary-bg)] rounded-lg border border-[var(--border-color)]",
+  clsx("sm:max-w-[600px] w-fit sm:w-full mx-2 sm:mx-auto my-8 p-8 bg-[var(--secondary-bg)] rounded-lg border border-[var(--border-color)]",
         {
           "relative": step.type === "home" //support the cog!
         }
@@ -689,7 +689,7 @@ export const WalletGuard = ({
           <h2 className="font-bold text-lg text-center">Unlock Wallet</h2>
 
           {wallets.find((w) => w.id === selectedWalletId) && (
-            <div className="selected-wallet-info">
+            <div className="text-center mb-5 p-2.5 bg-[#2c3e50] rounded">
               <span className="font-semibold text-[var(--text-primary)]">
                 {wallets.find((w) => w.id === selectedWalletId)?.name}
               </span>

--- a/src/containers/WalletGuard.tsx
+++ b/src/containers/WalletGuard.tsx
@@ -277,7 +277,7 @@ export const WalletGuard = ({
   
 
   const wrapperClass =
-  clsx("sm:max-w-[600px] w-fit sm:w-full mx-2 sm:mx-auto my-8 p-8 bg-[var(--secondary-bg)] rounded-lg border border-[var(--border-color)]",
+  clsx("sm:max-w-[600px] w-full sm:mx-auto my-8 p-8 bg-[var(--secondary-bg)] rounded-lg border border-[var(--border-color)]",
         {
           "relative": step.type === "home" //support the cog!
         }
@@ -350,16 +350,16 @@ export const WalletGuard = ({
             ))}
           </div>
 
-          <div className="flex gap-2 justify-center">
+          <div className="flex flex-col gap-2 justify-center sm:flex-row">
             <button
               onClick={() => onStepChange("create")}
-              className="bg-[var(--accent-blue)] text-white border-none py-3 px-6 rounded-lg cursor-pointer text-base transition-colors duration-200"
+              className="w-full sm:w-auto bg-[var(--accent-blue)] text-white font-bold py-3 px-4 sm:px-6 rounded-lg transition-colors duration-200"
             >
               Create New Wallet
             </button>
             <button
               onClick={() => onStepChange("import")}
-              className="bg-[var(--accent-blue)] text-white border-none py-3 px-6 rounded-lg cursor-pointer text-base transition-colors duration-200"
+              className="w-full sm:w-auto bg-[var(--accent-blue)] text-white font-bold py-3 px-4 sm:px-6 rounded-lg transition-colors duration-200"
             >
               Import Wallet
             </button>

--- a/src/index.css
+++ b/src/index.css
@@ -42,7 +42,6 @@ body {
     sans-serif;
   max-width: 1200px;
   margin: 0 auto;
-  padding: 20px;
   background-color: var(--primary-bg);
   color: var(--text-primary);
   line-height: 1.5;


### PR DESCRIPTION
Wait until [this](https://github.com/K-Kluster/Kasia/pull/89) is merged before merging.

## What?

- locks the view port on mobile, stops auto zooming etc. currently due to some elements being so small modern browsers will zoom for accessibility (if font is less than 16px for example). 
_I will address some of these in a subsequent PR once the current PRs are merged_
- mobile styling changes, primarily removes the margin space on mobile, making the app feel more 'native'. Side effects is wallet guard is now full-x (which is ok), but difficult to have control over without a further refactor.

**before:**
![image](https://github.com/user-attachments/assets/c6a79612-edea-48ce-b50b-3497a481baf8)

**after:**
![image](https://github.com/user-attachments/assets/123e9cd3-2403-4f77-b117-bd059f01a8ab)


