### PR TITLE
Style/homescreen

### DIFF
--- a/src/components/Layout/TrustMessage.tsx
+++ b/src/components/Layout/TrustMessage.tsx
@@ -9,7 +9,7 @@ export const TrustMessage: FC = () => {
   return (
     <>
       {/* trust message section */}
-      <div className="mt-8 rounded-lg border border-[#70C7BA]/20 bg-gradient-to-br from-[#70C7BA]/10 to-[#70C7BA]/5 p-2">
+      <div className="mt-6 rounded-lg border border-[#70C7BA]/20 bg-gradient-to-br from-[#70C7BA]/10 to-[#70C7BA]/5 p-2">
         <div
           className="flex cursor-pointer items-center justify-center gap-2"
           onClick={() => setOpenTrust((v) => !v)}
@@ -44,7 +44,7 @@ export const TrustMessage: FC = () => {
       </div>
 
       {/* why kaspa wallet section */}
-      <div className="mt-4 rounded-lg border border-[#B6B6B6]/20 bg-gradient-to-br from-[#B6B6B6]/10 to-[#B6B6B6]/5 p-2">
+      <div className="mt-3 rounded-lg border border-[#B6B6B6]/20 bg-gradient-to-br from-[#B6B6B6]/10 to-[#B6B6B6]/5 p-2">
         <div
           className="flex cursor-pointer items-center justify-center gap-2"
           onClick={() => setOpenWhy((v) => !v)}

--- a/src/containers/WalletFlow.css
+++ b/src/containers/WalletFlow.css
@@ -3,41 +3,6 @@
   color: white;
 }
 
-.form-group {
-  margin-bottom: 15px;
-}
-
-.form-group label {
-  display: block;
-  margin-bottom: 5px;
-  font-weight: 500;
-  color: white;
-}
-
-.form-group input,
-.form-group textarea {
-  width: 100%;
-  padding: 10px;
-  background-color: #1a1f2e;
-  border: 1px solid #2a3042;
-  border-radius: 4px;
-  font-size: 16px;
-  color: white;
-  transition: all 0.2s ease;
-}
-
-.form-group input:focus,
-.form-group textarea:focus {
-  outline: none;
-  border-color: #3a4156;
-  background-color: #1e2436;
-}
-
-.form-group textarea {
-  min-height: 100px;
-  resize: vertical;
-}
-
 .form-actions {
   display: flex;
   justify-content: space-between;
@@ -89,25 +54,6 @@
 .error::before {
   content: "⚠️";
   margin-right: 8px;
-}
-
-.form-group input {
-  width: 100%;
-  padding: 8px 12px;
-  border: 1px solid #2c3e50;
-  border-radius: 4px;
-  background-color: #34495e;
-  color: #ecf0f1;
-  transition: border-color 0.3s ease;
-}
-
-.form-group input:focus {
-  border-color: #3498db;
-  outline: none;
-}
-
-.form-group input.error {
-  border-color: #e74c3c;
 }
 
 .form-actions {
@@ -201,19 +147,6 @@
   font-size: 12px;
 }
 
-/* .selected-wallet-info {
-  text-align: center;
-  margin-bottom: 20px;
-  padding: 10px;
-  background-color: #2c3e50;
-  border-radius: 4px;
-}
-
-.selected-wallet-info .wallet-name {
-  font-weight: 600;
-  color: var(--text-primary);
-} */
-
 .radio-option {
   display: flex;
   align-items: flex-start;
@@ -251,29 +184,4 @@
 
 .radio-option input[type="radio"]:checked + span {
   color: var(--accent-blue);
-}
-
-/* Migration info styles
-.migration-info {
-  background-color: var(--primary-bg);
-  border: 1px solid var(--border-color);
-  border-radius: 8px;
-  padding: 1rem;
-  margin-bottom: 1.5rem;
-}
-
-.migration-info p {
-  margin: 0.5rem 0;
-  color: var(--text-primary);
-}
-
-.migration-info strong {
-  color: var(--accent-blue);
-} */
-
-/* Responsive adjustments */
-@media (max-width: 768px) {
-  .radio-option {
-    padding: 0.5rem;
-  }
 }

--- a/src/containers/WalletFlow.css
+++ b/src/containers/WalletFlow.css
@@ -253,7 +253,7 @@
   color: var(--accent-blue);
 }
 
-/* Migration info styles */
+/* Migration info styles
 .migration-info {
   background-color: var(--primary-bg);
   border: 1px solid var(--border-color);
@@ -269,7 +269,7 @@
 
 .migration-info strong {
   color: var(--accent-blue);
-}
+} */
 
 /* Responsive adjustments */
 @media (max-width: 768px) {

--- a/src/containers/WalletFlow.tsx
+++ b/src/containers/WalletFlow.tsx
@@ -556,81 +556,97 @@ export const WalletFlow = ({
         <>
           <h2 className="text-center text-lg font-bold">Import Wallet</h2>
 
-          {/* Derivation Type Selection */}
-          <div className="form-group">
-            <label>Derivation Standard</label>
-            <div className="mt-2 flex flex-col gap-2 sm:gap-3">
-              <label className="radio-option">
-                <input
-                  type="radio"
-                  name="derivationType"
-                  value="standard"
-                  checked={derivationType === "standard"}
-                  onChange={(e) =>
-                    setDerivationType(e.target.value as WalletDerivationType)
-                  }
-                />
-                <span>Standard (Recommended)</span>
-                <small>
-                  Compatible with Kaspium and other standard wallets
-                </small>
-              </label>
-              <label className="radio-option">
-                <input
-                  type="radio"
-                  name="derivationType"
-                  value="legacy"
-                  checked={derivationType === "legacy"}
-                  onChange={(e) =>
-                    setDerivationType(e.target.value as WalletDerivationType)
-                  }
-                />
-                <span>Legacy</span>
-                <small>For compatibility with older wallets</small>
-              </label>
-            </div>
-          </div>
+          <RadioGroup
+            name="derivationType"
+            value={derivationType}
+            onChange={setDerivationType}
+            className="mb-2 sm:mb-3"
+          >
+            <Label className="mb-1 block text-base font-semibold text-white sm:mb-3">
+              Derivation Standard
+            </Label>
 
-          <div className="form-group">
-            <label>Wallet Name</label>
-            <input ref={nameRef} type="text" placeholder="My Wallet" />
-          </div>
-          <div className="form-group">
-            <label>Seed Phrase Length</label>
-            <div className="mt-2 flex flex-col gap-2 sm:gap-3">
-              <label className="radio-option">
-                <input
-                  type="radio"
-                  name="importSeedLength"
-                  value="12"
-                  checked={seedPhraseLength === 12}
-                  onChange={() => setSeedPhraseLength(12)}
-                />
-                <span>12 words</span>
-              </label>
-              <label className="radio-option">
-                <input
-                  type="radio"
-                  name="importSeedLength"
-                  value="24"
-                  checked={seedPhraseLength === 24}
-                  onChange={() => setSeedPhraseLength(24)}
-                />
-                <span>24 words</span>
-              </label>
+            <div className="flex flex-col gap-2 sm:gap-3">
+              {[
+                {
+                  value: "standard",
+                  label: "Standard (Recommended)",
+                  description:
+                    "Compatible with Kaspium and other standard wallets",
+                },
+                {
+                  value: "legacy",
+                  label: "Legacy",
+                  description: "For compatibility with older wallets",
+                },
+              ].map((opt) => (
+                <Radio
+                  key={opt.value}
+                  as="label"
+                  value={opt.value}
+                  className="group hover:border-kas-secondary/50 flex cursor-pointer flex-col items-start gap-y-1 rounded-md border border-[var(--border-color)] bg-slate-900 p-3 transition-colors duration-200 hover:bg-slate-900/20 data-checked:border-[var(--color-kas-primary)] data-checked:bg-[var(--color-kas-primary)]/5"
+                >
+                  <span className="text-sm font-medium text-[var(--text-primary)] group-data-checked:text-[var(--color-kas-secondary)] sm:text-base">
+                    {opt.label}
+                  </span>
+                  <small className="text-xs text-[var(--text-secondary)] group-data-checked:text-[var(--color-kas-primary)] sm:text-sm">
+                    {opt.description}
+                  </small>
+                </Radio>
+              ))}
             </div>
-            <MnemonicEntry
-              seedPhraseLength={seedPhraseLength}
-              mnemonicRef={mnemonicRef}
+          </RadioGroup>
+
+          <div className="mb-2 sm:mb-3">
+            <label className="mb-1 block text-base font-semibold text-white sm:mb-3">
+              Wallet Name
+            </label>
+            <input
+              ref={nameRef}
+              type="text"
+              placeholder="My Wallet"
+              className="focus:!border-kas-primary w-full rounded border border-slate-700 bg-slate-900 p-2.5 text-base text-slate-100 transition-all duration-200 focus:!bg-slate-800 focus:outline-none"
             />
           </div>
 
-          <div className="form-group">
-            <label>Password</label>
+          <RadioGroup
+            name="importSeedLength"
+            value={seedPhraseLength.toString() as "12" | "24"}
+            onChange={(val) => setSeedPhraseLength(val === "24" ? 24 : 12)}
+            className="mb-2 sm:mb-3"
+          >
+            <Label className="mb-1 block text-base font-semibold text-white sm:mb-3">
+              Seed Phrase Length
+            </Label>
+            <div className="flex flex-col gap-2 sm:gap-3">
+              {["24", "12"].map((val) => (
+                <Radio
+                  key={val}
+                  as="label"
+                  value={val}
+                  className="group hover:border-kas-secondary/50 flex cursor-pointer flex-col items-start gap-y-1 rounded-md border border-[var(--border-color)] bg-slate-900 p-3 transition-colors duration-200 hover:bg-slate-900/20 data-checked:border-[var(--color-kas-primary)] data-checked:bg-[var(--color-kas-primary)]/5"
+                >
+                  <span className="text-sm font-medium text-[var(--text-primary)] group-data-checked:text-[var(--color-kas-secondary)] sm:text-base">
+                    {val} words
+                  </span>
+                </Radio>
+              ))}
+            </div>
+          </RadioGroup>
+          <MnemonicEntry
+            seedPhraseLength={seedPhraseLength}
+            mnemonicRef={mnemonicRef}
+          />
+
+          <div className="mb-2 sm:mb-3">
+            <label className="mb-1 block text-base font-semibold text-white sm:mb-3">
+              Password
+            </label>
             <input
               ref={passwordRef}
               type="password"
               placeholder="Enter password"
+              className="focus:!border-kas-primary w-full rounded border border-slate-700 bg-slate-900 p-2.5 text-base text-slate-100 transition-all duration-200 focus:!bg-slate-800 focus:outline-none"
             />
           </div>
 

--- a/src/containers/WalletFlow.tsx
+++ b/src/containers/WalletFlow.tsx
@@ -312,7 +312,7 @@ export const WalletFlow = ({
           <h2 className="mt-2 mb-2 text-center text-xl font-semibold text-[var(--text-primary)] sm:mt-2 sm:mb-3 sm:text-2xl">
             {wallets.length <= 0 ? "No Wallets Found" : "Select Wallet"}
           </h2>
-          <div className="mb-1 flex flex-col gap-2 sm:mb-3 sm:gap-4">
+          <div className="mb-3 flex flex-col gap-2 sm:gap-4">
             {wallets.map((w) => (
               <div
                 key={w.id}
@@ -373,7 +373,9 @@ export const WalletFlow = ({
       {/* Create wallet 'Route' */}
       {step.type === "create" && (
         <>
-          <h2 className="text-center text-lg font-bold">Create New Wallet</h2>
+          <h2 className="mb-1 text-center text-lg font-bold">
+            Create New Wallet
+          </h2>
 
           <RadioGroup
             name="derivationType"
@@ -381,7 +383,7 @@ export const WalletFlow = ({
             onChange={setDerivationType}
             className="mb-2 sm:mb-3"
           >
-            <Label className="mb-1 block text-base font-semibold text-white sm:mb-3">
+            <Label className="mb-3 block text-base font-semibold text-white">
               Derivation Standard
             </Label>
             <div className="flex flex-col gap-2 sm:gap-3">
@@ -415,8 +417,8 @@ export const WalletFlow = ({
             </div>
           </RadioGroup>
 
-          <div className="mb-2 sm:mb-3">
-            <label className="mb-1 block text-base font-semibold text-white sm:mb-3">
+          <div className="mb-3">
+            <label className="mb-3 block text-base font-semibold text-white">
               Wallet Name
             </label>
             <input
@@ -431,9 +433,9 @@ export const WalletFlow = ({
             name="seedLength"
             value={seedPhraseLength}
             onChange={setSeedPhraseLength}
-            className="mb-2 sm:mb-3"
+            className="mb-3"
           >
-            <Label className="mb-1 block text-base font-semibold text-white sm:mb-3">
+            <Label className="mb-3 block text-base font-semibold text-white">
               Seed Phrase Length
             </Label>
             <div className="flex flex-col gap-2 sm:gap-3">
@@ -466,8 +468,8 @@ export const WalletFlow = ({
             </div>
           </RadioGroup>
 
-          <div className="mb-2 sm:mb-3">
-            <label className="mb-1 block text-base font-semibold text-white sm:mb-3">
+          <div className="mb-3">
+            <label className="mb-3 block text-base font-semibold text-white">
               Wallet Name
             </label>
             <input
@@ -564,9 +566,9 @@ export const WalletFlow = ({
             name="derivationType"
             value={derivationType}
             onChange={setDerivationType}
-            className="mb-2 sm:mb-3"
+            className="mb-3"
           >
-            <Label className="mb-1 block text-base font-semibold text-white sm:mb-3">
+            <Label className="mb-3 block text-base font-semibold text-white">
               Derivation Standard
             </Label>
 
@@ -601,8 +603,8 @@ export const WalletFlow = ({
             </div>
           </RadioGroup>
 
-          <div className="mb-2 sm:mb-3">
-            <label className="mb-1 block text-base font-semibold text-white sm:mb-3">
+          <div className="mb-3">
+            <label className="mb-3 block text-base font-semibold text-white">
               Wallet Name
             </label>
             <input
@@ -619,7 +621,7 @@ export const WalletFlow = ({
             onChange={(val) => setSeedPhraseLength(val === "24" ? 24 : 12)}
             className="mb-2 sm:mb-3"
           >
-            <Label className="mb-1 block text-base font-semibold text-white sm:mb-3">
+            <Label className="mb-3 block text-base font-semibold text-white">
               Seed Phrase Length
             </Label>
             <div className="flex flex-col gap-2 sm:gap-3">
@@ -642,8 +644,8 @@ export const WalletFlow = ({
             mnemonicRef={mnemonicRef}
           />
 
-          <div className="mb-2 sm:mb-3">
-            <label className="mb-1 block text-base font-semibold text-white sm:mb-3">
+          <div className="mb-3">
+            <label className="mb-3 block text-base font-semibold text-white">
               Password
             </label>
             <input

--- a/src/containers/WalletFlow.tsx
+++ b/src/containers/WalletFlow.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useWalletStore } from "../store/wallet.store";
 import { Mnemonic } from "kaspa-wasm";
 import "./WalletFlow.css";
+import { Radio, RadioGroup, Label } from "@headlessui/react";
 import { NetworkSelector } from "./NetworkSelector";
 import { NetworkType } from "../types/all";
 import { Wallet, WalletDerivationType } from "src/types/wallet.type";
@@ -370,80 +371,106 @@ export const WalletFlow = ({
         <>
           <h2 className="text-center text-lg font-bold">Create New Wallet</h2>
 
-          {/* Derivation Type Selection */}
-          <div className="form-group">
-            <label>Derivation Standard</label>
-            <div className="mt-2 flex flex-col gap-2 sm:gap-3">
-              <label className="radio-option">
-                <input
-                  type="radio"
-                  name="derivationType"
-                  value="standard"
-                  checked={derivationType === "standard"}
-                  onChange={(e) =>
-                    setDerivationType(e.target.value as WalletDerivationType)
-                  }
-                />
-                <span className="ml-1">Standard (Recommended)</span>
-                <small>
-                  Compatible with Kaspium and other standard wallets
-                </small>
-              </label>
-              <label className="radio-option">
-                <input
-                  type="radio"
-                  name="derivationType"
-                  value="legacy"
-                  checked={derivationType === "legacy"}
-                  onChange={(e) =>
-                    setDerivationType(e.target.value as WalletDerivationType)
-                  }
-                />
-                <span className="ml-1">Legacy</span>
-                <small>For compatibility with older wallets</small>
-              </label>
+          <RadioGroup
+            name="derivationType"
+            value={derivationType}
+            onChange={setDerivationType}
+            className="mb-2 sm:mb-3"
+          >
+            <Label className="mb-1 block text-base font-semibold text-white sm:mb-3">
+              Derivation Standard
+            </Label>
+            <div className="flex flex-col gap-2 sm:gap-3">
+              {[
+                {
+                  value: "standard",
+                  label: "Standard (Recommended)",
+                  description:
+                    "Compatible with Kaspium and other standard wallets",
+                },
+                {
+                  value: "legacy",
+                  label: "Legacy",
+                  description: "For compatibility with older wallets",
+                },
+              ].map((opt) => (
+                <Radio
+                  key={opt.value}
+                  as="label"
+                  value={opt.value}
+                  className="group hover:border-kas-secondary/50 flex cursor-pointer flex-col items-start gap-y-1 rounded-md border border-[var(--border-color)] bg-slate-900 p-3 transition-colors duration-200 hover:bg-slate-900/20 data-checked:border-[var(--color-kas-primary)] data-checked:bg-[var(--color-kas-primary)]/5"
+                >
+                  <span className="text-sm font-medium text-[var(--text-primary)] group-data-checked:text-[var(--color-kas-secondary)] sm:text-base">
+                    {opt.label}
+                  </span>
+                  <small className="text-xs text-[var(--text-secondary)] group-data-checked:text-[var(--color-kas-primary)] sm:text-sm">
+                    {opt.description}
+                  </small>
+                </Radio>
+              ))}
             </div>
+          </RadioGroup>
+
+          <div className="mb-2 sm:mb-3">
+            <label className="mb-1 block text-base font-semibold text-white sm:mb-3">
+              Wallet Name
+            </label>
+            <input
+              ref={nameRef}
+              type="text"
+              placeholder="My Wallet"
+              className="focus:!border-kas-primary w-full rounded border border-slate-700 bg-slate-900 p-2.5 text-base text-slate-100 transition-all duration-200 focus:!bg-slate-800 focus:outline-none"
+            />
           </div>
 
-          <div className="form-group">
-            <label>Wallet Name</label>
-            <input ref={nameRef} type="text" placeholder="My Wallet" />
-          </div>
-
-          <div className="form-group">
-            <label>Seed Phrase Length</label>
-            <div className="mt-2 flex flex-col gap-2 sm:gap-3">
-              <label className="radio-option">
-                <input
-                  type="radio"
-                  name="seedLength"
-                  value="12"
-                  checked={seedPhraseLength === 12}
-                  onChange={() => setSeedPhraseLength(12)}
-                />
-                <span className="ml-1">12 words</span>
-                <small>128-bit entropy</small>
-              </label>
-              <label className="radio-option">
-                <input
-                  type="radio"
-                  name="seedLength"
-                  value="24"
-                  checked={seedPhraseLength === 24}
-                  onChange={() => setSeedPhraseLength(24)}
-                />
-                <span className="ml-1">24 words (Recommended)</span>
-                <small>256-bit entropy</small>
-              </label>
+          <RadioGroup
+            name="seedLength"
+            value={seedPhraseLength}
+            onChange={setSeedPhraseLength}
+            className="mb-2 sm:mb-3"
+          >
+            <Label className="mb-1 block text-base font-semibold text-white sm:mb-3">
+              Seed Phrase Length
+            </Label>
+            <div className="flex flex-col gap-2 sm:gap-3">
+              {[
+                {
+                  value: 24,
+                  label: "24 words (Recommended)",
+                  description: "256-bit entropy",
+                },
+                {
+                  value: 12,
+                  label: "12 words",
+                  description: "128-bit entropy",
+                },
+              ].map((opt) => (
+                <Radio
+                  key={opt.value}
+                  as="label"
+                  value={opt.value}
+                  className="group hover:border-kas-secondary/50 flex cursor-pointer flex-col items-start gap-y-1 rounded-md border border-[var(--border-color)] bg-slate-900 p-3 transition-colors duration-200 hover:bg-slate-900/20 data-checked:border-[var(--color-kas-primary)] data-checked:bg-[var(--color-kas-primary)]/5"
+                >
+                  <span className="text-sm font-medium text-[var(--text-primary)] group-data-checked:text-[var(--color-kas-secondary)] sm:text-base">
+                    {opt.label}
+                  </span>
+                  <small className="text-xs text-[var(--text-secondary)] group-data-checked:text-[var(--color-kas-primary)] sm:text-sm">
+                    {opt.description}
+                  </small>
+                </Radio>
+              ))}
             </div>
-          </div>
+          </RadioGroup>
 
-          <div className="form-group">
-            <label>Password</label>
+          <div className="mb-2 sm:mb-3">
+            <label className="mb-1 block text-base font-semibold text-white sm:mb-3">
+              Wallet Name
+            </label>
             <input
               ref={passwordRef}
               type="password"
               placeholder="Enter password"
+              className="focus:!border-kas-primary w-full rounded border border-slate-700 bg-slate-900 p-2.5 text-base text-slate-100 transition-all duration-200 focus:!bg-slate-800 focus:outline-none"
             />
           </div>
 
@@ -719,8 +746,10 @@ export const WalletFlow = ({
             </div>
           ) : (
             <>
-              <div className="form-group">
-                <label>Password</label>
+              <div className="mb-3.5">
+                <label className="mb-3.5 block font-medium text-white">
+                  Password
+                </label>
                 <input
                   data-1p-ignore
                   data-lpignore="true"
@@ -729,7 +758,10 @@ export const WalletFlow = ({
                   ref={usePasswordRef}
                   type="password"
                   placeholder="Enter your password"
-                  className={error ? "error" : ""}
+                  className={clsx(
+                    "focus:!border-kas-primary w-full rounded border border-slate-700 bg-slate-900 p-2.5 text-base text-slate-100 transition-all duration-200 focus:!bg-slate-800 focus:outline-none",
+                    { "!border-red-500": error }
+                  )}
                   onKeyDown={(e) => e.key === "Enter" && onUnlockWallet()}
                   disabled={unlocking}
                 />

--- a/src/containers/WalletFlow.tsx
+++ b/src/containers/WalletFlow.tsx
@@ -288,7 +288,14 @@ export const WalletFlow = ({
   const wrapperClass = clsx(
     "w-full bg-[var(--secondary-bg)] p-8",
     isMobile
-      ? "fixed inset-0 w-full max-h-screen overflow-y-auto"
+      ? clsx(
+          "fixed inset-0 w-full max-h-screen overflow-y-auto flex flex-col",
+          step.type === "home"
+            ? wallets.length > 2
+              ? "justify-start"
+              : "justify-center"
+            : "justify-start"
+        )
       : "mx-auto my-8 rounded-lg max-w-[600px] border border-[var(--border-color)]",
     { relative: step.type === "home" && !isMobile }
   );
@@ -301,7 +308,12 @@ export const WalletFlow = ({
           <Link to="/settings-network">
             <Cog6ToothIcon className="absolute top-4 right-4 size-6 hover:cursor-pointer hover:opacity-80" />
           </Link>
-          <div className="mb-1 flex grow items-center justify-center">
+          <div
+            className={clsx(
+              "mb-1 flex items-center justify-center",
+              isMobile ? "grow-0" : "grow"
+            )}
+          >
             <NetworkSelector
               selectedNetwork={selectedNetwork}
               onNetworkChange={onNetworkChange}

--- a/src/containers/WalletFlow.tsx
+++ b/src/containers/WalletFlow.tsx
@@ -22,6 +22,7 @@ import clsx from "clsx";
 import { TrustMessage } from "../components/Layout/TrustMessage";
 import { toast } from "../utils/toast";
 import { Button } from "../components/Common/Button";
+import { useIsMobile } from "../utils/useIsMobile";
 
 export type Step = {
   type:
@@ -66,6 +67,8 @@ export const WalletFlow = ({
   const passwordRef = useRef<HTMLInputElement>(null);
   const mnemonicRef = useRef<HTMLTextAreaElement>(null);
   const nameRef = useRef<HTMLInputElement>(null);
+
+  const isMobile = useIsMobile();
 
   const usePasswordRef = useCallback((node: HTMLInputElement | null) => {
     passwordRef.current = node;
@@ -283,10 +286,11 @@ export const WalletFlow = ({
     );
 
   const wrapperClass = clsx(
-    "sm:max-w-[600px] w-full mx-auto my-8 p-8 bg-[var(--secondary-bg)] rounded-lg border border-[var(--border-color)]",
-    {
-      relative: step.type === "home", //support the cog!
-    }
+    "w-full bg-[var(--secondary-bg)] p-8",
+    isMobile
+      ? "fixed inset-0 w-full max-h-screen overflow-y-auto"
+      : "mx-auto my-8 rounded-lg max-w-[600px] border border-[var(--border-color)]",
+    { relative: step.type === "home" && !isMobile }
   );
 
   return (

--- a/src/containers/WalletFlow.tsx
+++ b/src/containers/WalletFlow.tsx
@@ -682,48 +682,50 @@ export const WalletFlow = ({
       {/* Migrate wallet 'Route' */}
       {step.type === "migrate" && (
         <>
-          <h2 className="text-center text-lg font-bold">
+          <h2 className="mb-1 text-center text-lg font-bold sm:mb-3">
             Migrate Legacy Wallet
           </h2>
-          <div className="migration-info">
-            <p>
+          <div className="mb-4 rounded-lg border border-[var(--border-color)] bg-[var(--primary-bg)] p-4">
+            <p className="mb-2 font-semibold text-[var(--text-primary)]">
               Migrating wallet:{" "}
-              <strong>
+              <strong className="text-[var(--accent-blue)]">
                 {wallets.find((w) => w.id === step.walletId)?.name}
               </strong>
             </p>
-            <p>
+            <p className="my-2 text-[var(--text-secondary)]">
               This will create a new wallet using the standard Kaspa derivation
               path (m/44'/111111'/0') that is compatible with Kaspium and other
               standard wallets.
             </p>
-            <div className="my-5 flex flex-col items-center rounded-lg border border-[#2a3042] bg-[#1a1f2e] p-4 text-center text-amber-300">
+            <div className="mt-5 mb-1 flex flex-col items-center rounded-lg border border-[#2a3042] bg-[#1a1f2e] p-4 text-center text-amber-300">
               <ExclamationTriangleIcon className="h-5 w-5" /> Your original
               wallet will remain unchanged. You'll need to transfer funds to the
               new wallet addresses.
             </div>
           </div>
 
-          <div className="form-group">
-            <label>New Wallet Name</label>
+          <div className="mb-2 sm:mb-3">
+            <label className="mb-1 block text-base font-semibold text-white sm:mb-3">
+              New Wallet Name
+            </label>
             <input
               ref={nameRef}
               type="text"
-              placeholder={`${
-                wallets.find((w) => w.id === step.walletId)?.name
-              } (Standard)`}
-              defaultValue={`${
-                wallets.find((w) => w.id === step.walletId)?.name
-              } (Standard)`}
+              placeholder={`${wallets.find((w) => w.id === step.walletId)?.name} (Standard)`}
+              defaultValue={`${wallets.find((w) => w.id === step.walletId)?.name} (Standard)`}
+              className="focus:!border-kas-primary w-full rounded border border-slate-700 bg-slate-900 p-2.5 text-base text-slate-100 transition-all duration-200 focus:!bg-slate-800 focus:outline-none"
             />
           </div>
 
-          <div className="form-group">
-            <label>Password</label>
+          <div className="mb-2 sm:mb-3">
+            <label className="mb-1 block text-base font-semibold text-white sm:mb-3">
+              Password
+            </label>
             <input
               ref={passwordRef}
               type="password"
               placeholder="Enter your current wallet password"
+              className="focus:!border-kas-primary w-full rounded border border-slate-700 bg-slate-900 p-2.5 text-base text-slate-100 transition-all duration-200 focus:!bg-slate-800 focus:outline-none"
             />
           </div>
 

--- a/src/containers/WalletFlow.tsx
+++ b/src/containers/WalletFlow.tsx
@@ -273,11 +273,11 @@ export const WalletFlow = ({
 
   const getDerivationTypeDisplay = (d?: WalletDerivationType) =>
     d === "standard" ? (
-      <span className="rounded bg-emerald-500 px-2 py-1 text-xs font-medium text-white">
+      <span className="bg-kas-primary rounded px-2 py-1 text-xs font-medium text-white">
         Standard (Kaspium Compatible)
       </span>
     ) : (
-      <span className="rounded bg-amber-500 px-2 py-1 text-xs font-medium text-white">
+      <span className="rounded bg-amber-400 px-2 py-1 text-xs font-medium text-white">
         Legacy
       </span>
     );
@@ -305,15 +305,15 @@ export const WalletFlow = ({
             />
           </div>
           <TrustMessage />
-          <h2 className="mt-4 mb-2 text-center text-[1.5rem] font-semibold text-[var(--text-primary)]">
+          <h2 className="mt-2 mb-2 text-center text-xl font-semibold text-[var(--text-primary)] sm:mt-2 sm:mb-3 sm:text-2xl">
             {wallets.length <= 0 ? "No Wallets Found" : "Select Wallet"}
           </h2>
-          <div className="mb-4 flex flex-col gap-2 sm:gap-4">
+          <div className="mb-1 flex flex-col gap-2 sm:mb-3 sm:gap-4">
             {wallets.map((w) => (
               <div
                 key={w.id}
                 onClick={() => onSelectWallet(w)}
-                className="relative flex cursor-pointer flex-col items-start gap-4 rounded-lg border border-[var(--border-color)] bg-[var(--primary-bg)] p-4 sm:flex-row sm:items-center sm:justify-between"
+                className="hover:border-kas-secondary/50 relative flex cursor-pointer flex-col items-start gap-2 rounded-lg border border-[var(--border-color)] bg-[var(--primary-bg)] p-4 hover:bg-slate-900/20 sm:flex-row sm:items-center sm:justify-between"
               >
                 {/* delete icon top-right */}
                 <button
@@ -321,18 +321,18 @@ export const WalletFlow = ({
                     e.stopPropagation();
                     onDeleteWallet(w.id);
                   }}
-                  className="absolute top-2 right-2 cursor-pointer p-1 text-red-500 hover:text-red-700"
+                  className="absolute top-2 right-2 cursor-pointer p-1 text-red-400 hover:text-red-700"
                   title="Delete"
                 >
                   <TrashIcon className="h-6 w-6" />
                 </button>
 
-                <div className="flex flex-col gap-2">
+                <div className="flex flex-col gap-1">
                   <div className="inline-flex items-center space-x-1 font-semibold text-[var(--text-primary)]">
                     <span>{w.name}</span>
                   </div>
 
-                  <div className="text-sm text-[var(--text-secondary)]">
+                  <div className="text-xs text-[var(--text-secondary)] sm:text-sm">
                     Created: {new Date(w.createdAt).toLocaleDateString()}
                   </div>
                   <div className="mt-1 flex items-center gap-2">
@@ -359,7 +359,7 @@ export const WalletFlow = ({
             <Button variant="primary" onClick={() => onStepChange("create")}>
               Create New Wallet
             </Button>
-            <Button variant="primary" onClick={() => onStepChange("import")}>
+            <Button variant="secondary" onClick={() => onStepChange("import")}>
               Import Wallet
             </Button>
           </div>

--- a/src/utils/useIsMobile.ts
+++ b/src/utils/useIsMobile.ts
@@ -1,15 +1,21 @@
 import { useState, useEffect } from "react";
 
 export function useIsMobile(breakpoint = 640) {
-  const mq = `(max-width: ${breakpoint - 1}px)`;
-  const [isMobile, set] = useState(() => matchMedia(mq).matches);
+  const [isMobile, setIsMobile] = useState(false);
 
   useEffect(() => {
-    const mql = matchMedia(mq);
-    const onChange = (e: MediaQueryListEvent) => set(e.matches);
+    if (typeof window === "undefined") return;
+
+    const query = `(max-width: ${breakpoint - 1}px)`;
+    const mql = window.matchMedia(query);
+
+    // set initial value on mount
+    setIsMobile(mql.matches);
+
+    const onChange = (e: MediaQueryListEvent) => setIsMobile(e.matches);
     mql.addEventListener("change", onChange);
     return () => mql.removeEventListener("change", onChange);
-  }, [mq]);
+  }, [breakpoint]);
 
   return isMobile;
 }


### PR DESCRIPTION
## What?

major styling overhaul for wallet-flow aka the locked homescreen

changes:
- replace radio buttons with headless ui radio groups
- restyle input fields
- adjust spacing
- softened a bunch of colors
- adjusted useIsMobile hook due to bug
- take out css for tailwind

on mobile:
- made the home-screen 'full screen'

notes:
- aware of the repetition in the component adjustments, the whole wallet flow needs a refactor (there are bigger things to work on though) so we can deal with it then. this should make it easier.
- I ended up getting *very* hacky with the wrapper class styling, mainly because I don't want all the items at the top of the page. some styling that would *make sense* adds other undesirable effects.

## Testing
nest everything, do a full flow of: creating wallet > unlocking > check address > deleting > importing the same wallet > check address > migrate > delete > restore.

note: none of the logic has changed, but last thing I want is that there's a bug in something critical like expected behavior for wallet gen.

note-2: if its all good - merge, deploy to staging and see how it feels on a real wallet. adjust accordingly