### PR TITLE
fix: speed up message start

### DIFF
--- a/src/AppRoutes.tsx
+++ b/src/AppRoutes.tsx
@@ -1,4 +1,3 @@
-// src/AppRoutes.tsx
 import React from "react";
 import { Routes, Route, Navigate } from "react-router-dom";
 import { RootLayout } from "./components/Layout/RootLayout";
@@ -8,6 +7,7 @@ import { OneLiner } from "./OneLiner";
 import { SettingsPage } from "./SettingsPage";
 import type { NetworkType } from "./types/all";
 import type { Step } from "./containers/WalletFlow";
+import { useWalletStore } from "./store/wallet.store";
 
 type WalletFlowRouteConfig = {
   path: string | undefined;
@@ -31,46 +31,56 @@ export const AppRoutes: React.FC<AppRoutesProps> = ({
   network,
   isConnected,
   onNetworkChange,
-}) => (
-  <Routes>
-    <Route element={<RootLayout />}>
-      {/* Home */}
-      <Route
-        index
-        element={
-          <WalletFlow
-            initialStep="home"
-            selectedNetwork={network}
-            onNetworkChange={onNetworkChange}
-            isConnected={isConnected}
-          />
-        }
-      />
+}) => {
+  const { unlockedWallet, selectedWalletId } = useWalletStore();
 
-      <Route path="wallet">
-        {/* index for /wallet */}
-        <Route index element={<Navigate to="/" replace />} />
-        {walletFlowRoutes.map(({ path, initialStep }) => (
-          <Route
-            key={path!}
-            path={path!}
-            element={
-              <WalletFlow
-                initialStep={initialStep}
-                selectedNetwork={network}
-                onNetworkChange={onNetworkChange}
-                isConnected={isConnected}
-              />
-            }
-          />
-        ))}
-      </Route>
+  return (
+    <Routes>
+      <Route element={<RootLayout />}>
+        {/* Home */}
+        <Route
+          index
+          element={
+            <WalletFlow
+              initialStep="home"
+              selectedNetwork={network}
+              onNetworkChange={onNetworkChange}
+              isConnected={isConnected}
+            />
+          }
+        />
 
-      {/* Main Oneliner once you are unlocked */}
-      <Route element={<RequireUnlockedWallet />}>
-        <Route path=":walletId" element={<OneLiner />} />
+        <Route path="wallet">
+          {/* index for /wallet */}
+          <Route index element={<Navigate to="/" replace />} />
+          {walletFlowRoutes.map(({ path, initialStep }) => (
+            <Route
+              key={path!}
+              path={path!}
+              element={
+                initialStep === "unlock" &&
+                unlockedWallet &&
+                selectedWalletId ? (
+                  <Navigate to={`/${selectedWalletId}`} replace />
+                ) : (
+                  <WalletFlow
+                    initialStep={initialStep}
+                    selectedNetwork={network}
+                    onNetworkChange={onNetworkChange}
+                    isConnected={isConnected}
+                  />
+                )
+              }
+            />
+          ))}
+        </Route>
+
+        {/* Main Oneliner once you are unlocked */}
+        <Route element={<RequireUnlockedWallet />}>
+          <Route path=":walletId" element={<OneLiner />} />
+        </Route>
+        <Route path="settings-network" element={<SettingsPage />} />
       </Route>
-      <Route path="settings-network" element={<SettingsPage />} />
-    </Route>
-  </Routes>
-);
+    </Routes>
+  );
+};

--- a/src/containers/WalletFlow.tsx
+++ b/src/containers/WalletFlow.tsx
@@ -119,7 +119,7 @@ export const WalletFlow = ({
         navigate(`/wallet/migrate/${walletId ?? ""}`);
         break;
       case "unlocked":
-        navigate(`/${walletId ?? "/"}`);
+        console.log("Navigated to Oneliner");
         break;
       default:
         return;

--- a/src/store/wallet.store.ts
+++ b/src/store/wallet.store.ts
@@ -221,17 +221,13 @@ export const useWalletStore = create<WalletState>((set, get) => {
         if (!currentRpcClient) {
           throw new Error("RPC client not initialized");
         }
-
         wallet.client = currentRpcClient;
         set({ unlockedWallet: wallet });
-
         _accountService = new AccountService(currentRpcClient, wallet);
         _accountService.setPassword(password);
-
         // Connect the account service to the messaging store
         const messagingStore = useMessagingStore.getState();
         messagingStore.connectAccountService(_accountService);
-
         // Set up event listeners
         _accountService.on("balance", (balance) => {
           set({ balance });


### PR DESCRIPTION
## What

this pr moves the routing logic for navigating to an unlocked wallet out of `WalletFlow` and into `AppRoutes`, using the `unlockedWallet` store state as the trigger.

previously in `WalletFlow.onUnlockWallet` we awaited the async unlock before routing:

```ts
await unlock(selectedWalletId, pass);
onStepChange("unlocked", selectedWalletId);
```
since unlock already updates the store to mark the wallet as unlocked (during the unlock process) , we can react to that state change and navigate directly to OneLiner.

note:
the current connection state and store is somewhat bloated and inefficient- so like a lot of stuff this is just a quick win until we can do a proper refactor.

note 2: we could further optimize client initialization inside of startMessageClient in OneLiner, but let’s save that for a future pr.