### PR TITLE
feat: add avatar hashes for collapsed list

### DIFF
--- a/src/components/ContactCard.tsx
+++ b/src/components/ContactCard.tsx
@@ -2,6 +2,7 @@ import { FC, useMemo, useState } from "react";
 import { Contact } from "../types/all";
 import { decodePayload } from "../utils/all-in-one";
 import { useMessagingStore } from "../store/messaging.store";
+import { AvatarHash } from "./icons/AvatarHash";
 import {
   PencilIcon,
   CheckCircleIcon,
@@ -135,23 +136,23 @@ export const ContactCard: FC<{
 
   // Collapsed w/ Avatar
   if (collapsed) {
-    const avatar =
-      contact.nickname?.trim()?.[0]?.toUpperCase() ??
-      contact.address.split(":")[1]?.[0]?.toUpperCase() ??
-      "?";
-
+    const avatarLetter = contact.nickname?.trim()?.[0]?.toUpperCase();
     return (
       <div
         className={clsx(
           "flex cursor-pointer justify-center py-2",
-          isSelected && "bg-[var(--accent-blue)]/20"
+          isSelected && "bg-kas-primary/40"
         )}
         title={displayName}
         onClick={() => onClick?.(contact)}
       >
-        <div className="flex h-8 w-8 items-center justify-center rounded-full bg-[var(--accent-blue)] text-sm font-semibold text-white">
-          {avatar}
-        </div>
+        {avatarLetter ? (
+          <div className="bg-kas-primary/40 flex h-8 w-8 items-center justify-center rounded-full text-sm font-semibold text-white">
+            {avatarLetter}
+          </div>
+        ) : (
+          <AvatarHash address={contact.address} size={32} />
+        )}
       </div>
     );
   }

--- a/src/components/icons/AvatarHash.tsx
+++ b/src/components/icons/AvatarHash.tsx
@@ -1,0 +1,52 @@
+import React, { FC, useMemo } from "react";
+
+const kaspaPalette = ["#70C7BA", "#231F20", "#B6B6B6", "#49EACB"];
+
+export const AvatarHash: FC<{ address: string; size?: number }> = ({
+  address,
+  size = 32,
+}) => {
+  const hash = useMemo(() => {
+    let h = 0;
+    for (let i = 0; i < address.length; i++) {
+      h = (h << 5) - h + address.charCodeAt(i);
+      h |= 0;
+    }
+    return h;
+  }, [address]);
+
+  const cellSize = size / 5;
+  const coords = useMemo(() => {
+    const out: { x: number; y: number }[] = [];
+    let idx = 0;
+    for (let x = 0; x < 3; x++) {
+      for (let y = 0; y < 5; y++) {
+        if ((hash >> idx) & 1) {
+          out.push({ x, y }, { x: 4 - x, y });
+        }
+        idx++;
+      }
+    }
+    return out;
+  }, [hash]);
+
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox={`0 0 ${size} ${size}`}
+      className="rounded-full bg-gray-500"
+    >
+      {coords.map(({ x, y }, i) => (
+        <rect
+          key={i}
+          x={x * cellSize}
+          y={y * cellSize}
+          width={cellSize}
+          height={cellSize}
+          fill={kaspaPalette[(hash >> i) & (kaspaPalette.length - 1)]}
+        />
+      ))}
+    </svg>
+  );
+};


### PR DESCRIPTION
## What?

based on an idea from someone in discord,  I figured it might be nice for us to have little avatar images (until we have the ability to add photos etc later).
color palette is based on the kaspa media kit colors.

behavior is that if you add a nick name, that will over write this.

![image](https://github.com/user-attachments/assets/82f714b3-5cf9-4670-b75b-f332c0668d91)
