### PR TITLE
Fix/uiandpayment

### DIFF
--- a/src/components/Common/ToastContainer.tsx
+++ b/src/components/Common/ToastContainer.tsx
@@ -11,12 +11,12 @@ export function ToastContainer() {
   const { toasts, remove } = useToastStore();
 
   return (
-    <div className="fixed top-16 right-4 z-60 space-y-2 sm:top-4">
+    <div className="sm:5/6 fixed top-16 right-4 z-60 max-w-1/2 space-y-2 break-all sm:top-4">
       {toasts.map((toast) => (
         <div
           key={toast.id}
           className={clsx(
-            "animate-fade-in flex items-center gap-2 rounded-xl px-2 py-1 text-sm shadow-lg sm:px-4 sm:py-3",
+            "animate-fade-in flex items-center gap-2 rounded-xl px-2 py-1 text-sm break-words shadow-lg sm:px-4 sm:py-3",
             {
               "bg-green-100/80 text-green-900": toast.type === "success",
               "bg-red-100/80 text-red-900": toast.type === "error",

--- a/src/components/MessageDisplay.tsx
+++ b/src/components/MessageDisplay.tsx
@@ -190,7 +190,7 @@ export const MessageDisplay: FC<MessageDisplayProps> = ({
               </div>
               <div className="flex-1">
                 {hasMessage && (
-                  <div className="mb-1 text-sm font-medium text-white drop-shadow-sm">
+                  <div className="mb-1 text-sm font-medium break-all text-white drop-shadow-sm">
                     {paymentPayload.message}
                   </div>
                 )}

--- a/src/containers/SendPayment.tsx
+++ b/src/containers/SendPayment.tsx
@@ -302,7 +302,7 @@ export const SendPayment: FC<{
                     <button
                       type="button"
                       onClick={handleMaxPayClick}
-                      className="border-kas-primary absolute top-1/2 right-2 -translate-y-1/2 transform rounded-sm border px-1 py-0.5 text-xs font-medium text-[#70C7BA] hover:opacity-80"
+                      className="border-kas-primary absolute top-1/2 right-2 -translate-y-1/2 transform cursor-pointer rounded-sm border px-1 py-0.5 text-xs font-medium text-[#70C7BA] hover:opacity-80"
                     >
                       Max
                     </button>
@@ -318,13 +318,14 @@ export const SendPayment: FC<{
                   onClick={handleSendPayment}
                   disabled={isSendingPayment || !payAmount}
                   className={clsx(
-                    "h-10 w-full rounded-md px-4 py-2 text-sm font-medium transition duration-200 md:w-auto",
+                    "h-10 w-full rounded-md px-4 py-2 text-sm font-medium transition duration-200",
                     "bg-[#70C7BA] text-white hover:bg-[#5fb5a3] focus:ring-2 focus:ring-[#70C7BA] focus:outline-none",
+                    "self-center md:w-auto md:self-auto",
                     {
                       "cursor-not-allowed opacity-50":
                         isSendingPayment || !payAmount,
-                    },
-                    "self-center md:self-auto"
+                      "cursor-pointer": payAmount && !isSendingPayment,
+                    }
                   )}
                 >
                   {isSendingPayment ? "Sending…" : "Send KAS"}


### PR DESCRIPTION
## what?

style fixes:
allows crude line breaking on toast messages and payment messages
adds cursor pointers to payment buttons

in chat payment:
fixes back where max send tried to send all funds without taking into account the payload and fees