### PR TITLE
feat: qrscan + misc

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "cipher": "file:cipher-wasm",
         "clsx": "^2.1.1",
         "eventemitter3": "^5.0.1",
+        "jsqr": "^1.4.0",
         "kaspa-wasm": "file:wasm",
         "qrcode": "^1.5.4",
         "react": "^19.0.0",
@@ -5063,6 +5064,11 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/jsqr": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsqr/-/jsqr-1.4.0.tgz",
+      "integrity": "sha512-dxLob7q65Xg2DvstYkRpkYtmKm2sPJ9oFhrhmudT1dZvNFFTlroai3AWSpLey/w5vMcLBXRgOJsbXpdN9HzU/A=="
     },
     "node_modules/kaspa-wasm": {
       "resolved": "wasm",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "cipher": "file:cipher-wasm",
     "clsx": "^2.1.1",
     "eventemitter3": "^5.0.1",
+    "jsqr": "^1.4.0",
     "kaspa-wasm": "file:wasm",
     "qrcode": "^1.5.4",
     "react": "^19.0.0",

--- a/src/components/Common/ToastContainer.tsx
+++ b/src/components/Common/ToastContainer.tsx
@@ -11,7 +11,7 @@ export function ToastContainer() {
   const { toasts, remove } = useToastStore();
 
   return (
-    <div className="sm:5/6 fixed top-16 right-4 z-60 max-w-1/2 space-y-2 break-all sm:top-4">
+    <div className="fixed top-16 right-4 z-60 max-w-5/6 space-y-2 break-all sm:top-4 sm:max-w-1/2">
       {toasts.map((toast) => (
         <div
           key={toast.id}

--- a/src/components/Common/modal.tsx
+++ b/src/components/Common/modal.tsx
@@ -1,14 +1,19 @@
 import { FC, ReactNode } from "react";
 import { XMarkIcon } from "@heroicons/react/24/solid";
+import clsx from "clsx";
 
 // Basic modal component to standardise the look
 // Pass in your children - this just provides the bare minimum
-export const Modal: FC<{ onClose: () => void; children: ReactNode }> = ({
-  onClose,
-  children,
-}) => (
+export const Modal: FC<{
+  onClose: () => void;
+  children: ReactNode;
+  className?: string;
+}> = ({ onClose, children, className }) => (
   <div
-    className="modalFadeIn fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+    className={clsx(
+      "fixed inset-0 z-50 flex items-center justify-center bg-black/50",
+      className
+    )}
     onClick={onClose}
   >
     <div

--- a/src/components/Modals/WalletWithdrawal.tsx
+++ b/src/components/Modals/WalletWithdrawal.tsx
@@ -4,6 +4,7 @@ import { kaspaToSompi, sompiToKaspaString } from "kaspa-wasm";
 import { useWalletStore } from "../../store/wallet.store";
 import { Button } from "../Common/Button";
 import { toast } from "../../utils/toast";
+import { QrScanner } from "../QrScanner";
 
 const maxDustAmount = kaspaToSompi("0.19")!;
 
@@ -118,14 +119,20 @@ export const WalletWithdrawal: FC = () => {
     <>
       <h4 className="text-lg font-semibold">Withdraw KAS</h4>
       <div className="mt-2">
-        <textarea
-          value={withdrawAddress}
-          onChange={(e) => setWithdrawAddress(e.target.value)}
-          placeholder="Enter Kaspa address"
-          rows={2}
-          className="mb-2 w-full resize-none rounded-md border border-white/20 bg-black/30 p-2 break-words whitespace-pre-wrap text-white"
-        />
-
+        <div className="flex items-center gap-2">
+          <textarea
+            value={withdrawAddress}
+            onChange={(e) => setWithdrawAddress(e.target.value)}
+            placeholder="Enter Kaspa address"
+            rows={3}
+            className="mb-2 w-full resize-none rounded-md border border-white/20 bg-black/30 p-2 break-words whitespace-pre-wrap text-white"
+          />
+          <QrScanner
+            onScan={(data: string) => {
+              setWithdrawAddress(data.toLowerCase());
+            }}
+          />
+        </div>
         <div className="flex items-center gap-2">
           <div className="relative flex-1">
             <input

--- a/src/components/NewChatForm.tsx
+++ b/src/components/NewChatForm.tsx
@@ -14,6 +14,7 @@ import { unknownErrorToErrorLike } from "../utils/errors";
 import { KaspaAddress } from "./KaspaAddress";
 import { Textarea } from "@headlessui/react";
 import { Button } from "./Common/Button";
+import { QrScanner } from "./QrScanner";
 
 interface NewChatFormProps {
   onClose: () => void;
@@ -390,20 +391,27 @@ export const NewChatForm: React.FC<NewChatFormProps> = ({ onClose }) => {
           >
             Recipient Address
           </label>
-          <Textarea
-            ref={useRecipientInputRef}
-            className="box-border flex w-full resize-none items-center rounded-md border border-white/10 bg-black/30 px-3 py-2 font-mono text-base leading-[1.4] text-white lowercase placeholder-white/50 transition-colors duration-200 hover:border-white/20 hover:bg-white/10 focus:border-white/20 focus:bg-white/10 focus:outline-none disabled:bg-black/50 disabled:text-white/30"
-            rows={2}
-            id="recipientAddress"
-            value={recipientInputValue}
-            onChange={(e) =>
-              setRecipientInputValue(e.target.value.toLowerCase())
-            }
-            placeholder="Kaspa address or Kns domain"
-            disabled={isLoading}
-            required
-            autoComplete="off"
-          />
+          <div className="flex items-center gap-2">
+            <Textarea
+              ref={useRecipientInputRef}
+              className="box-border flex w-full resize-none items-center rounded-md border border-white/10 bg-black/30 px-3 py-2 font-mono text-base leading-[1.4] text-white lowercase placeholder-white/50 transition-colors duration-200 hover:border-white/20 hover:bg-white/10 focus:border-white/20 focus:bg-white/10 focus:outline-none disabled:bg-black/50 disabled:text-white/30"
+              rows={3}
+              id="recipientAddress"
+              value={recipientInputValue}
+              onChange={(e) =>
+                setRecipientInputValue(e.target.value.toLowerCase())
+              }
+              placeholder="Kaspa address or Kns domain"
+              disabled={isLoading}
+              required
+              autoComplete="off"
+            />
+            <QrScanner
+              onScan={(data: string) => {
+                setRecipientInputValue(data.toLowerCase());
+              }}
+            />
+          </div>
           {isResolvingKns && detectedRecipientInputValueFormat === "kns" && (
             <div className={styles["checking-text"]}>
               Resolving KNS domain...

--- a/src/components/QrScanner.tsx
+++ b/src/components/QrScanner.tsx
@@ -1,0 +1,150 @@
+import React, { useRef, useEffect, useState } from "react";
+import jsQR from "jsqr";
+import { CameraIcon } from "@heroicons/react/24/solid";
+import { toast } from "../utils/toast";
+import clsx from "clsx";
+import { Modal } from "./Common/modal";
+
+interface QrScannerProps {
+  onScan: (data: string) => void;
+}
+
+export const QrScanner: React.FC<QrScannerProps> = ({ onScan }) => {
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const [stream, setStream] = useState<MediaStream | null>(null);
+  const [showModal, setShowModal] = useState(false);
+  const [hasCamera, setHasCamera] = useState<boolean | null>(null);
+
+  // check for camera devices on mount - which includes components this is placed in
+  useEffect(() => {
+    navigator.mediaDevices?.enumerateDevices?.().then((devices) => {
+      const hasCam = devices.some((device) => device.kind === "videoinput");
+      setHasCamera(hasCam);
+    });
+  }, []);
+
+  // start camera when modal opens
+  useEffect(() => {
+    if (!showModal) return;
+    if (showModal && !hasCamera) {
+      // just in case
+      toast.error("Device does not have a supported Camera");
+      setShowModal(false);
+      return;
+    }
+    let localStream: MediaStream | null = null;
+    let cancelled = false;
+
+    const waitForVideoAndStartCamera = async () => {
+      let attempts = 0;
+      while (!videoRef.current && attempts < 20) {
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        attempts++;
+      }
+      if (!videoRef.current) {
+        toast.error("Video element not able to start");
+        setShowModal(false);
+        return;
+      }
+      if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
+        toast.error("Camera API not supported. Needs HTTPS");
+        setShowModal(false);
+        return;
+      }
+      try {
+        localStream = await navigator.mediaDevices.getUserMedia({
+          video: { facingMode: "environment" },
+        });
+        if (videoRef.current && !cancelled) {
+          videoRef.current.srcObject = localStream;
+          videoRef.current.setAttribute("playsinline", "true");
+          await videoRef.current.play();
+          setStream(localStream);
+        }
+      } catch (err: unknown) {
+        const msg =
+          "Could not access camera: " +
+          (err instanceof Error ? err.message : String(err));
+        toast.error(msg);
+        setShowModal(false);
+      }
+    };
+
+    waitForVideoAndStartCamera();
+
+    return () => {
+      cancelled = true;
+      if (localStream) {
+        localStream.getTracks().forEach((track) => track.stop());
+      }
+      setStream(null);
+    };
+  }, [showModal, hasCamera]);
+
+  // scan when stream is ready
+  useEffect(() => {
+    if (!stream) return;
+    let id: number;
+    // create an offscreen canvas for scanning
+    const canvas = document.createElement("canvas");
+    const tick = () => {
+      const v = videoRef.current;
+      if (v && v.readyState === v.HAVE_ENOUGH_DATA) {
+        canvas.width = v.videoWidth;
+        canvas.height = v.videoHeight;
+        const ctx = canvas.getContext("2d");
+        if (ctx) {
+          ctx.drawImage(v, 0, 0, canvas.width, canvas.height);
+          const code = jsQR(
+            ctx.getImageData(0, 0, canvas.width, canvas.height).data,
+            canvas.width,
+            canvas.height
+          );
+          if (code) {
+            onScan(code.data);
+            setShowModal(false);
+            return;
+          }
+        }
+      }
+      id = requestAnimationFrame(tick);
+    };
+    id = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(id);
+  }, [stream, onScan]);
+
+  return (
+    <>
+      <button
+        type="button"
+        className={clsx(
+          "rounded bg-gray-700 p-2 text-white hover:bg-gray-600",
+          {
+            "cursor-pointer": hasCamera,
+            hidden: !hasCamera,
+          }
+        )}
+        onClick={() => hasCamera && setShowModal(true)}
+        title={hasCamera ? "Scan QR code" : "No camera available"}
+        disabled={!hasCamera}
+      >
+        <CameraIcon className="h-5 w-5" />
+      </button>
+      {/* need to lift the z of the modal because its usually stacked on another modal */}
+      {showModal && (
+        <Modal onClose={() => setShowModal(false)} className={"z-60"}>
+          <div className="flex flex-col items-center border-none bg-transparent p-4">
+            <video
+              ref={videoRef}
+              autoPlay
+              muted
+              playsInline
+              className="w-full rounded-sm shadow"
+            />
+            <div className="mt-2 text-gray-200 italic">Find a KAS QR</div>
+          </div>
+        </Modal>
+      )}
+    </>
+  );
+};


### PR DESCRIPTION
## what
- adds `jsqr` for decoding qr codes (note: jsqr doesn't handle camera input, only decoding from images, its bundle size is comparatively good). 

- adds the `QrScanner` component for scanning and the likes

- enables qr code scanning in new chats and withdraw. 

note: unlike the other soft standard where we have a parent button that calls a component, this component includes its own button so it can hide if the useEffectt detects no camera. sorta an all in one type thing.

styling is bare minimum and I haven't tested on desktop.

also includes small changes: 
- adjusted width of the toast container for better display on mobile (well it fixes incomplete tailwind - from earlier me).

- added classnames as a prop to our common modal component for easier styling overrides.

## testing
needs https for camera access. used ngrok personally but use whatever works or test on staging.
