### PR TITLE
feat: propagate nickname to message section header

### DIFF
--- a/src/components/NewChatForm.tsx
+++ b/src/components/NewChatForm.tsx
@@ -278,7 +278,7 @@ export const NewChatForm: React.FC<NewChatFormProps> = ({ onClose }) => {
       // Initiate handshake with custom amount
 
       await messageStore.initiateHandshake(knsRecipientAddress, amountSompi);
-      messageStore.setOpenedRecipient(recipientInputValue);
+      messageStore.setOpenedRecipient(knsRecipientAddress);
 
       if (
         detectedRecipientInputValueFormat === "kns" &&

--- a/src/containers/ContactSection.tsx
+++ b/src/containers/ContactSection.tsx
@@ -9,6 +9,7 @@ import { ContactCard } from "../components/ContactCard";
 import { Contact } from "../types/all";
 import { useIsMobile } from "../utils/useIsMobile";
 import { useUiStore } from "../store/ui.store";
+import { useMessagingStore } from "../store/messaging.store";
 
 interface ContactSectionProps {
   contacts: Contact[];

--- a/src/containers/MessagesSection.tsx
+++ b/src/containers/MessagesSection.tsx
@@ -269,9 +269,11 @@ export const MessageSection: FC<{
               <KaspaAddress address={openedRecipient ?? ""} />
             </h3>
 
-            <div className="flex items-center gap-3">
-              {address && <FetchApiMessages address={address.toString()} />}
-            </div>
+            {openedRecipient && (
+              <div className="flex items-center gap-3">
+                {address && <FetchApiMessages address={address.toString()} />}
+              </div>
+            )}
           </div>
 
           <div

--- a/src/store/messaging.store.ts
+++ b/src/store/messaging.store.ts
@@ -97,6 +97,7 @@ export const useMessagingStore = create<MessagingState>((set, g) => ({
   openedRecipient: null,
   contacts: [],
   messages: [],
+
   messagesOnOpenedRecipient: [],
   handshakes: [],
   addContacts: (contacts) => {


### PR DESCRIPTION
## What?
Nicknames can now be displayed in he message section header.

![image](https://github.com/user-attachments/assets/4d9ec161-b795-4ebb-a859-6815bf5fce87)
