### PR TITLE
Feature/pending failed message icons

### DIFF
--- a/src/components/MessageDisplay.tsx
+++ b/src/components/MessageDisplay.tsx
@@ -7,7 +7,7 @@ import { CipherHelper } from "../utils/cipher-helper";
 import { useMessagingStore } from "../store/messaging.store";
 import { HandshakeResponse } from "./HandshakeResponse";
 import { KasIcon } from "./icons/KasCoin";
-import { Paperclip, Tickets } from "lucide-react";
+import { Paperclip, Tickets, Loader2, X } from "lucide-react";
 import clsx from "clsx";
 import { parseMessageForDisplay } from "../utils/message-format";
 import { PROTOCOL_PREFIX, PAYMENT_PREFIX } from "../config/protocol";
@@ -157,28 +157,6 @@ export const MessageDisplay: FC<MessageDisplayProps> = ({
       );
     }
     return null; // Don't show amount for any messages
-  };
-
-  // Render status for failed or pending
-  const formatStatus = () => {
-    if (status === "failed") {
-      return (
-        <div className="w-full">
-          <div className="message-fee text-right text-xs text-red-500">
-            {status}
-          </div>
-        </div>
-      );
-    }
-    if (status === "pending") {
-      return (
-        <div className="w-full">
-          <div className="message-fee text-accent-yellow text-right text-xs">
-            {status}
-          </div>
-        </div>
-      );
-    }
   };
 
   // Render payment message content
@@ -512,16 +490,20 @@ export const MessageDisplay: FC<MessageDisplayProps> = ({
           : "justify-start pl-0.5 sm:pl-2"
       )}
     >
-      {showMeta && transactionId && isOutgoing && (
+      {showMeta && isOutgoing && (
         <div className="mr-2 flex items-center">
-          <a
-            href={getExplorerUrl(transactionId)}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-xs opacity-80 transition-opacity hover:opacity-100"
-          >
-            <Tickets className="size-5" />
-          </a>
+          {status === "sent" && transactionId && (
+            <a
+              href={getExplorerUrl(transactionId)}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-xs opacity-80 transition-opacity hover:opacity-100"
+            >
+              <Tickets className="size-5" />
+            </a>
+          )}
+          {status === "pending" && <Loader2 className="size-5 animate-spin" />}
+          {status === "failed" && <X className="size-5 text-red-500" />}
         </div>
       )}
       <div
@@ -553,7 +535,6 @@ export const MessageDisplay: FC<MessageDisplayProps> = ({
             )}
           >
             {formatAmountAndFee()}
-            {formatStatus()}
           </div>
         )}
       </div>

--- a/src/components/MessageDisplay.tsx
+++ b/src/components/MessageDisplay.tsx
@@ -503,7 +503,9 @@ export const MessageDisplay: FC<MessageDisplayProps> = ({
             </a>
           )}
           {status === "pending" && <Loader2 className="size-5 animate-spin" />}
-          {status === "failed" && <X className="size-5 text-red-500" />}
+          {status === "failed" && (
+            <X className="size-5 text-[var(--accent-red)]" />
+          )}
         </div>
       )}
       <div

--- a/src/components/MessageDisplay.tsx
+++ b/src/components/MessageDisplay.tsx
@@ -28,6 +28,7 @@ export const MessageDisplay: FC<MessageDisplayProps> = ({
   const [showMeta, setShowMeta] = useState(false);
 
   const {
+    status,
     senderAddress,
     recipientAddress,
     timestamp,
@@ -156,6 +157,28 @@ export const MessageDisplay: FC<MessageDisplayProps> = ({
       );
     }
     return null; // Don't show amount for any messages
+  };
+
+  // Render status for failed or pending
+  const formatStatus = () => {
+    if (status === "failed") {
+      return (
+        <div className="w-full">
+          <div className="message-fee text-right text-xs text-red-500">
+            {status}
+          </div>
+        </div>
+      );
+    }
+    if (status === "pending") {
+      return (
+        <div className="w-full">
+          <div className="message-fee text-accent-yellow text-right text-xs">
+            {status}
+          </div>
+        </div>
+      );
+    }
   };
 
   // Render payment message content
@@ -508,6 +531,7 @@ export const MessageDisplay: FC<MessageDisplayProps> = ({
           isOutgoing
             ? "border border-[var(--button-primary)] bg-[var(--button-primary)]/20"
             : "bg-[var(--secondary-bg)]",
+          status !== "sent" && "bg-text-secondary/10",
           bubbleClass
         )}
       >
@@ -529,6 +553,7 @@ export const MessageDisplay: FC<MessageDisplayProps> = ({
             )}
           >
             {formatAmountAndFee()}
+            {formatStatus()}
           </div>
         )}
       </div>

--- a/src/containers/SendMessageForm.tsx
+++ b/src/containers/SendMessageForm.tsx
@@ -36,6 +36,7 @@ import { MAX_PAYLOAD_SIZE } from "../config/constants";
 import { prepareFileForUpload } from "../utils/upload-file-handler";
 import { useIsMobile } from "../utils/useIsMobile";
 import { parseImageFileJson } from "../utils/parse-image-file";
+import { v4 as uuidv4 } from "uuid";
 
 type SendMessageFormProps = {
   onExpand?: () => void;
@@ -237,7 +238,7 @@ export const SendMessageForm: FC<SendMessageFormProps> = ({ onExpand }) => {
 
       // Create the message object for storage
       pendingMessage = {
-        transactionId: "",
+        transactionId: uuidv4(),
         status: "pending", // Initial status is pending
         senderAddress: walletStore.address.toString(),
         recipientAddress: recipient,

--- a/src/containers/SendMessageForm.tsx
+++ b/src/containers/SendMessageForm.tsx
@@ -36,7 +36,6 @@ import { MAX_PAYLOAD_SIZE } from "../config/constants";
 import { prepareFileForUpload } from "../utils/upload-file-handler";
 import { useIsMobile } from "../utils/useIsMobile";
 import { parseImageFileJson } from "../utils/parse-image-file";
-import { v4 as uuidv4 } from "uuid";
 
 type SendMessageFormProps = {
   onExpand?: () => void;
@@ -234,11 +233,11 @@ export const SendMessageForm: FC<SendMessageFormProps> = ({ onExpand }) => {
         // Not a file message, use message as is
       }
 
-      let txId: string = "";
+      let txId: string;
 
       // Create the message object for storage
       pendingMessage = {
-        transactionId: uuidv4(),
+        transactionId: `pending-${Date.now()}-${Math.random()}`,
         status: "pending", // Initial status is pending
         senderAddress: walletStore.address.toString(),
         recipientAddress: recipient,
@@ -290,7 +289,7 @@ export const SendMessageForm: FC<SendMessageFormProps> = ({ onExpand }) => {
       }
       setIsExpanded(false);
 
-      if (txId === "") {
+      if (txId.startsWith("pending")) {
         pendingMessage = {
           ...pendingMessage,
           status: "failed",

--- a/src/store/messaging.store.ts
+++ b/src/store/messaging.store.ts
@@ -170,10 +170,18 @@ export const useMessagingStore = create<MessagingState>((set, g) => ({
     g().refreshMessagesOnOpenedRecipient();
   },
   updateMessage: (newMessage: Message) => {
-    const fullMessages = g().messages.map((msg) =>
+    const fullMessages = g().messages;
+    const updatedMessages = fullMessages.map((msg) =>
       msg.timestamp === newMessage.timestamp ? { ...msg, ...newMessage } : msg
     );
-    set({ messages: fullMessages });
+    // used to update the message in the UI
+    const openedRecipient = g().openedRecipient;
+    set({
+      messages: updatedMessages,
+      messagesOnOpenedRecipient: updatedMessages.filter(
+        (m) => m.recipientAddress === openedRecipient
+      ),
+    });
   },
   flushWalletHistory: (address: string) => {
     // 1. Clear wallet messages from localStorage using new per-address system

--- a/src/store/messaging.store.ts
+++ b/src/store/messaging.store.ts
@@ -55,6 +55,7 @@ interface MessagingState {
   messagesOnOpenedRecipient: Message[];
   handshakes: HandshakeState[];
   addMessages: (messages: Message[]) => void;
+  updateMessage: (newMessage: Message) => void;
   flushWalletHistory: (address: string) => void;
   addContacts: (contacts: Contact[]) => void;
   loadMessages: (address: string) => Message[];
@@ -167,6 +168,12 @@ export const useMessagingStore = create<MessagingState>((set, g) => ({
     }
 
     g().refreshMessagesOnOpenedRecipient();
+  },
+  updateMessage: (newMessage: Message) => {
+    const fullMessages = g().messages.map((msg) =>
+      msg.timestamp === newMessage.timestamp ? { ...msg, ...newMessage } : msg
+    );
+    set({ messages: fullMessages });
   },
   flushWalletHistory: (address: string) => {
     // 1. Clear wallet messages from localStorage using new per-address system

--- a/src/types/all.ts
+++ b/src/types/all.ts
@@ -1,6 +1,7 @@
 import { FeeSource, ITransaction } from "kaspa-wasm";
 
 export type Message = {
+  status?: "sent" | "pending" | "failed";
   transactionId: string;
   senderAddress: string;
   recipientAddress: string;


### PR DESCRIPTION
This commit is a fix to issue #150 and also adding icons to show pending and failed messages.


<img width="261" height="272" alt="image" src="https://github.com/user-attachments/assets/c1cf6d2f-0797-47b3-8797-a4354a9c51dd" />
 