### PR TITLE
feat: add BIP39 passphrase support for wallet import/recovery

### DIFF
--- a/src/components/MnemonicEntry.tsx
+++ b/src/components/MnemonicEntry.tsx
@@ -1,4 +1,5 @@
 import React, { useState, ClipboardEvent, ChangeEvent, useEffect } from "react";
+import { Switch } from "@headlessui/react";
 import clsx from "clsx";
 
 interface MnemonicEntryProps {
@@ -82,18 +83,33 @@ export const MnemonicEntry = ({
       <textarea ref={mnemonicRef} readOnly className="hidden" />
 
       <div className="mt-4 mb-4">
-        <label className="flex items-center gap-2 text-sm">
-          <input
-            type="checkbox"
+        <label className="flex items-center gap-3 text-sm">
+          <Switch
             checked={showPassphrase}
-            onChange={(e) => setShowPassphrase(e.target.checked)}
-            className="rounded border-[var(--primary-border)] bg-[var(--input-bg)] text-[var(--color-kas-secondary)] focus:ring-[var(--color-kas-secondary)]"
-          />
+            onChange={setShowPassphrase}
+            className={clsx(
+              "relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:ring-2 focus:ring-[var(--color-kas-secondary)] focus:ring-offset-2 focus:outline-none",
+              {
+                "bg-[var(--color-kas-secondary)]": showPassphrase,
+                "bg-[var(--primary-border)]": !showPassphrase,
+              }
+            )}
+          >
+            <span
+              className={clsx(
+                "inline-block h-4 w-4 transform rounded-full bg-white transition-transform",
+                {
+                  "translate-x-6": showPassphrase,
+                  "translate-x-1": !showPassphrase,
+                }
+              )}
+            />
+          </Switch>
           <span className="text-[var(--text-primary)]">
             My wallet has a passphrase (BIP39)
           </span>
         </label>
-        <p className="mt-1 text-xs text-[var(--text-secondary)]">
+        <p className="mt-3 text-xs text-[var(--text-secondary)]">
           Check this box if your wallet was created with an additional
           passphrase for extra security.
         </p>
@@ -116,7 +132,7 @@ export const MnemonicEntry = ({
               "placeholder:text-sm"
             )}
           />
-          <p className="mt-1 text-xs text-[var(--text-secondary)]">
+          <p className="mt-3 text-xs text-[var(--text-secondary)]">
             A passphrase adds an extra layer of security to your wallet. Only
             enter one if your wallet was created with a passphrase.
           </p>

--- a/src/components/MnemonicEntry.tsx
+++ b/src/components/MnemonicEntry.tsx
@@ -4,22 +4,26 @@ import clsx from "clsx";
 interface MnemonicEntryProps {
   seedPhraseLength: number;
   mnemonicRef: React.RefObject<HTMLTextAreaElement | null>;
+  passphraseRef?: React.RefObject<HTMLInputElement | null>;
 }
 
 export const MnemonicEntry = ({
   seedPhraseLength,
   mnemonicRef,
+  passphraseRef,
 }: MnemonicEntryProps) => {
   const [focusedIndex, setFocusedIndex] = useState<number | null>(null);
+  const [showPassphrase, setShowPassphrase] = useState(false);
 
   // If the user changes the seed phrase length, reset the input fields
   useEffect(() => {
     if (mnemonicRef.current) mnemonicRef.current.value = "";
+    if (passphraseRef?.current) passphraseRef.current.value = "";
     document
       .querySelectorAll<HTMLInputElement>(".mnemonic-input-grid input")
       .forEach((i) => (i.value = ""));
     setFocusedIndex(null);
-  }, [seedPhraseLength]);
+  }, [seedPhraseLength, mnemonicRef, passphraseRef]);
 
   const handlePaste = (e: ClipboardEvent<HTMLInputElement>, idx: number) => {
     if (idx !== 0) return;
@@ -76,6 +80,48 @@ export const MnemonicEntry = ({
         })}
       </div>
       <textarea ref={mnemonicRef} readOnly className="hidden" />
+
+      <div className="mt-4 mb-4">
+        <label className="flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            checked={showPassphrase}
+            onChange={(e) => setShowPassphrase(e.target.checked)}
+            className="rounded border-[var(--primary-border)] bg-[var(--input-bg)] text-[var(--color-kas-secondary)] focus:ring-[var(--color-kas-secondary)]"
+          />
+          <span className="text-[var(--text-primary)]">
+            My wallet has a passphrase (BIP39)
+          </span>
+        </label>
+        <p className="mt-1 text-xs text-[var(--text-secondary)]">
+          Check this box if your wallet was created with an additional
+          passphrase for extra security.
+        </p>
+      </div>
+
+      {showPassphrase && (
+        <div className="mt-4 mb-4">
+          <label className="mb-3 block text-base font-semibold text-[var(--text-primary)]">
+            Passphrase (Optional)
+          </label>
+          <input
+            ref={passphraseRef}
+            type="password"
+            placeholder="Enter passphrase (leave empty if none)"
+            className={clsx(
+              "w-full rounded-xl p-2",
+              "border-primary-border border bg-[var(--primary-bg)]",
+              "text-[var(--text-primary)]",
+              "focus:border-[var(--color-kas-secondary)] focus:outline-none",
+              "placeholder:text-sm"
+            )}
+          />
+          <p className="mt-1 text-xs text-[var(--text-secondary)]">
+            A passphrase adds an extra layer of security to your wallet. Only
+            enter one if your wallet was created with a passphrase.
+          </p>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/containers/WalletFlow.tsx
+++ b/src/containers/WalletFlow.tsx
@@ -68,6 +68,7 @@ export const WalletFlow = ({
   const [unlocking, setUnlocking] = useState(false);
   const passwordRef = useRef<HTMLInputElement>(null);
   const mnemonicRef = useRef<HTMLTextAreaElement>(null);
+  const passphraseRef = useRef<HTMLInputElement>(null);
   const nameRef = useRef<HTMLInputElement>(null);
 
   const isMobile = useIsMobile();
@@ -205,7 +206,14 @@ export const WalletFlow = ({
     }
     try {
       const mnemonic = new Mnemonic(mnemonicRef.current.value);
-      await createWallet(nameRef.current.value, mnemonic, pw, derivationType);
+      const passphrase = passphraseRef.current?.value || undefined;
+      await createWallet(
+        nameRef.current.value,
+        mnemonic,
+        pw,
+        derivationType,
+        passphrase
+      );
       setStep({ type: "success" });
     } catch (err) {
       setError({
@@ -214,6 +222,7 @@ export const WalletFlow = ({
       });
     } finally {
       if (mnemonicRef.current.value) mnemonicRef.current.value = "";
+      if (passphraseRef.current?.value) passphraseRef.current.value = "";
       if (passwordRef.current?.value) passwordRef.current.value = "";
     }
   };
@@ -677,9 +686,11 @@ export const WalletFlow = ({
               ))}
             </div>
           </RadioGroup>
+
           <MnemonicEntry
             seedPhraseLength={seedPhraseLength}
             mnemonicRef={mnemonicRef}
+            passphraseRef={passphraseRef}
           />
 
           <div className="mb-6">

--- a/src/store/wallet.store.ts
+++ b/src/store/wallet.store.ts
@@ -60,7 +60,8 @@ type WalletState = {
     name: string,
     mnemonic: Mnemonic,
     password: string,
-    derivationType?: WalletDerivationType
+    derivationType?: WalletDerivationType,
+    passphrase?: string
   ) => Promise<string>;
   deleteWallet: (walletId: string) => void;
   unlock: (
@@ -144,13 +145,15 @@ export const useWalletStore = create<WalletState>((set, get) => {
       name: string,
       mnemonic: Mnemonic,
       password: string,
-      derivationType?: WalletDerivationType
+      derivationType?: WalletDerivationType,
+      passphrase?: string
     ) => {
       const walletId = _walletStorage.create(
         name,
         mnemonic,
         password,
-        derivationType
+        derivationType,
+        passphrase
       );
       get().loadWallets();
       return walletId;

--- a/src/types/wallet.type.ts
+++ b/src/types/wallet.type.ts
@@ -20,6 +20,7 @@ export type UnlockedWallet = {
   client?: KaspaClient;
   // Add derivation type to unlocked wallet
   derivationType: WalletDerivationType;
+  passphrase?: string;
 };
 
 export type StoredWallet = {
@@ -30,6 +31,7 @@ export type StoredWallet = {
   accounts: { name: string }[];
   // Add derivation type to track wallet standard
   derivationType?: WalletDerivationType; // Optional for backward compatibility
+  encryptedPassphrase?: string;
 };
 
 export type WalletBalance = {


### PR DESCRIPTION
- Add optional passphrase field to MnemonicEntry component with toggle
- Update wallet storage to encrypt/decrypt passphrases securely
- Modify wallet creation to use passphrase in seed generation
- Extend wallet types to support encrypted passphrase storage
- Preserve passphrase during wallet migration and password changes
- Enables importing Kasware wallets with both seed phrase and passphrase

Fixes #155