### PR TITLE
Refactor/protocol const /1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kasia",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kasia",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "dependencies": {
         "@headlessui/react": "2.2.1",
         "@tailwindcss/vite": "4.1.3",

--- a/src/components/ContactCard.tsx
+++ b/src/components/ContactCard.tsx
@@ -2,7 +2,7 @@ import { FC, useMemo, useState, useEffect, useRef } from "react";
 import { decodePayload } from "../utils/format";
 import { useMessagingStore } from "../store/messaging.store";
 import { AvatarHash } from "./icons/AvatarHash";
-import { PROTOCOL, DELIM, VERSION } from "../config/protocol";
+import { PROTOCOL } from "../config/protocol";
 import clsx from "clsx";
 import { Contact } from "../store/repository/contact.repository";
 
@@ -80,8 +80,10 @@ export const ContactCard: FC<{
     if (addr === "Unknown") {
       if (lastEvent?.__type === PROTOCOL.headers.HANDSHAKE.type) {
         try {
+          // use protocol constants instead of hardcoded regex
+          const handshakePrefix = `${PROTOCOL.prefix.string}${PROTOCOL.headers.HANDSHAKE.string}`;
           const handshakeMatch = lastEvent.content.match(
-            /ciph_msg:1:handshake:(.+)/
+            new RegExp(`${handshakePrefix}(.+)`)
           );
           if (handshakeMatch) {
             const handshakeData = JSON.parse(handshakeMatch[1]);
@@ -90,7 +92,7 @@ export const ContactCard: FC<{
             }
           }
         } catch (e) {
-          // Ignore parsing errors for handshake alias extraction
+          // ignore parsing errors for handshake alias extraction
           void e;
         }
       }

--- a/src/components/ContactCard.tsx
+++ b/src/components/ContactCard.tsx
@@ -2,6 +2,7 @@ import { FC, useMemo, useState, useEffect, useRef } from "react";
 import { decodePayload } from "../utils/format";
 import { useMessagingStore } from "../store/messaging.store";
 import { AvatarHash } from "./icons/AvatarHash";
+import { PROTOCOL, DELIM, VERSION } from "../config/protocol";
 import clsx from "clsx";
 import { Contact } from "../store/repository/contact.repository";
 
@@ -14,7 +15,7 @@ function getMessagePreview(content: string) {
   }
 
   // For regular messages, try to decode if it's encrypted
-  if (content.startsWith("ciph_msg:")) {
+  if (content.startsWith(PROTOCOL.prefix.string)) {
     const decoded = decodePayload(content);
     return decoded
       ? decoded.slice(0, 40) + (content.length > 40 ? "..." : "")
@@ -51,9 +52,9 @@ export const ContactCard: FC<{
     switch (__type) {
       case "message":
         return getMessagePreview(content);
-      case "payment":
+      case PROTOCOL.headers.PAYMENT.type:
         return "Payment received";
-      case "handshake":
+      case PROTOCOL.headers.HANDSHAKE.type:
         if (oneOnOneConversation?.conversation.theirAlias) {
           return "Handshake completed";
         }
@@ -77,7 +78,7 @@ export const ContactCard: FC<{
     if (!contact?.kaspaAddress) return "Unknown";
     const addr = contact.kaspaAddress;
     if (addr === "Unknown") {
-      if (lastEvent?.__type === "handshake") {
+      if (lastEvent?.__type === PROTOCOL.headers.HANDSHAKE.type) {
         try {
           const handshakeMatch = lastEvent.content.match(
             /ciph_msg:1:handshake:(.+)/

--- a/src/components/MessageDisplay.tsx
+++ b/src/components/MessageDisplay.tsx
@@ -8,7 +8,7 @@ import clsx from "clsx";
 import { parseMessageForDisplay } from "../utils/message-format";
 import { Contact } from "../store/repository/contact.repository";
 import { Conversation } from "../store/repository/conversation.repository";
-import { PROTOCOL, DELIM } from "../config/protocol";
+import { PROTOCOL } from "../config/protocol";
 
 type MessageDisplayProps = {
   event: KasiaConversationEvent;

--- a/src/components/MessageDisplay.tsx
+++ b/src/components/MessageDisplay.tsx
@@ -8,6 +8,7 @@ import clsx from "clsx";
 import { parseMessageForDisplay } from "../utils/message-format";
 import { Contact } from "../store/repository/contact.repository";
 import { Conversation } from "../store/repository/conversation.repository";
+import { PROTOCOL } from "../config/protocol";
 
 type MessageDisplayProps = {
   event: KasiaConversationEvent;

--- a/src/components/MessageDisplay.tsx
+++ b/src/components/MessageDisplay.tsx
@@ -8,7 +8,7 @@ import clsx from "clsx";
 import { parseMessageForDisplay } from "../utils/message-format";
 import { Contact } from "../store/repository/contact.repository";
 import { Conversation } from "../store/repository/conversation.repository";
-import { PROTOCOL } from "../config/protocol";
+import { PROTOCOL, DELIM } from "../config/protocol";
 
 type MessageDisplayProps = {
   event: KasiaConversationEvent;
@@ -71,7 +71,7 @@ export const MessageDisplay: FC<MessageDisplayProps> = ({
     try {
       const paymentPayload = JSON.parse(event.content);
 
-      if (paymentPayload.type === "payment") {
+      if (paymentPayload.type === PROTOCOL.headers.PAYMENT.type) {
         // Check if message is empty or just whitespace
         const hasMessage =
           paymentPayload.message && paymentPayload.message.trim();

--- a/src/components/SendPaymentPopup.tsx
+++ b/src/components/SendPaymentPopup.tsx
@@ -9,6 +9,7 @@ import { encrypt_message } from "cipher";
 import { Address } from "kaspa-wasm";
 import { toast } from "../utils/toast";
 import { KasiaTransaction } from "../types/all";
+import { PROTOCOL } from "../config/protocol";
 
 export const SendPaymentPopup: FC<{
   address: string;
@@ -81,7 +82,7 @@ export const SendPaymentPopup: FC<{
 
       // Create simplified payment payload without aliases
       const paymentPayload = {
-        type: "payment",
+        type: PROTOCOL.headers.PAYMENT.type,
         message: message,
         amount: Number(amountSompi) / 100000000, // Convert sompi to KAS for payload
         timestamp: Date.now(),
@@ -99,10 +100,7 @@ export const SendPaymentPopup: FC<{
       }
 
       // Create the simplified payment protocol payload (no alias needed)
-      const prefix = "ciph_msg";
-      const version = "1";
-      const messageType = "payment";
-      const payload = `${prefix}:${version}:${messageType}:${encryptedMessage.to_hex()}`;
+      const payload = `${PROTOCOL.prefix.string}${PROTOCOL.headers.PAYMENT.string}${encryptedMessage.to_hex()}`;
 
       // Convert the payload to hex
       const payloadHex = payload
@@ -123,7 +121,7 @@ export const SendPaymentPopup: FC<{
 
       // Create and store outgoing payment message record (simplified)
       const paymentContent = JSON.stringify({
-        type: "payment",
+        type: PROTOCOL.headers.PAYMENT.type,
         message: message ?? "",
         amount: Number(amountSompi) / 100000000,
         timestamp: Date.now(),

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -6,6 +6,9 @@ export const FEE_ESTIMATE_POLLING_INTERVAL_IN_MS = 2 * ONE_MINUTE_IN_MS;
 
 export const ALIAS_LENGTH = 6; // 6 bytes = 12 hex characters
 
+// Placeholder alias for fee estimation and testing (12 hex chars = 6 bytes)
+export const PLACEHOLDER_ALIAS = "000000000000";
+
 // Maximum priority fee (5 KAS) - Originally 10 but lowering for intial release
 export const MAX_PRIORITY_FEE = BigInt(5 * 100_000_000);
 

--- a/src/config/protocol.ts
+++ b/src/config/protocol.ts
@@ -1,7 +1,32 @@
-export const PROTOCOL_PREFIX = "636970685f6d73673a"; //for ciph_message
+type Kind = "ciph_msg" | "handshake" | "comm" | "payment";
+type Prefix = { type: Kind; string: string; hex: string };
 
-export const HANDSHAKE_PREFIX = "313a68616e647368616b653a"; // for 1:handshake
+const VERSION = "1";
+const DELIM = ":";
 
-export const COMM_PREFIX = "313a636f6d6d3a"; // for 1:comm
+// Universal string to hex conversion
+const toHex = (s: string): string =>
+  Array.from(new TextEncoder().encode(s))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
 
-export const PAYMENT_PREFIX = "313a7061796d656e743a"; // "1:payment:" in hex
+const mk = <K extends Exclude<Kind, "ciph_msg">>(k: K): Prefix => {
+  const str = `${VERSION}${DELIM}${k}${DELIM}`;
+  return { type: k, string: str, hex: toHex(str) };
+};
+
+const PROTOCOL_PREFIX = {
+  // no need for separate type cast
+  type: "ciph_msg",
+  string: `ciph_msg${DELIM}`,
+  hex: toHex(`ciph_msg${DELIM}`),
+} as const;
+
+export const PROTOCOL = {
+  prefix: PROTOCOL_PREFIX,
+  headers: {
+    HANDSHAKE: mk("handshake"),
+    COMM: mk("comm"),
+    PAYMENT: mk("payment"),
+  },
+} as const;

--- a/src/config/protocol.ts
+++ b/src/config/protocol.ts
@@ -1,8 +1,8 @@
 type Kind = "ciph_msg" | "handshake" | "comm" | "payment";
 type Prefix = { type: Kind; string: string; hex: string };
 
-const VERSION = "1";
-const DELIM = ":";
+export const VERSION = "1";
+export const DELIM = ":";
 
 // Universal string to hex conversion
 const toHex = (s: string): string =>

--- a/src/service/account-service.ts
+++ b/src/service/account-service.ts
@@ -38,7 +38,7 @@ import { useMessagingStore } from "../store/messaging.store";
 import { useWalletStore } from "../store/wallet.store";
 import { WalletStorage } from "../utils/wallet-storage";
 import { useDBStore } from "../store/db.store";
-import { PROTOCOL } from "../config/protocol";
+import { PROTOCOL, VERSION } from "../config/protocol";
 import { PLACEHOLDER_ALIAS } from "../config/constants";
 
 // Message related types
@@ -905,7 +905,8 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
       destinationAddress.toString() === this.receiveAddress?.toString();
 
     const isMessageTransaction =
-      transaction.payload && transaction.payload.startsWith(PROTOCOL.prefix.hex);
+      transaction.payload &&
+      transaction.payload.startsWith(PROTOCOL.prefix.hex);
 
     const isSelfMessage = isMessageTransaction && isDirectSelfMessage;
     console.log("Transaction type:", {
@@ -1499,9 +1500,9 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
     }
 
     // Create the payload with conversation context
-    const prefix = "ciph_msg";
-    const version = "1"; // Use the current protocol version
-    const messageType = "comm"; // Use comm type for conversation messages
+    const prefix = PROTOCOL.prefix.type;
+    const version = VERSION; // Use the current protocol version
+    const messageType = PROTOCOL.headers.COMM.type; // Use comm type for conversation messages
     const payload = `${prefix}:${version}:${messageType}:${
       sendMessage.theirAlias
     }:${encryptedMessage.to_hex()}`;

--- a/src/store/db.store.ts
+++ b/src/store/db.store.ts
@@ -7,7 +7,7 @@ import {
   loadLegacyMessages,
   loadMessagesForAddress,
 } from "../utils/storage-encryption";
-import { PAYMENT_PREFIX, PROTOCOL_PREFIX } from "../config/protocol";
+import { PROTOCOL } from "../config/protocol";
 import { Message } from "./repository/message.repository";
 import { Handshake } from "./repository/handshake.repository";
 import { Payment } from "./repository/payment.repository";
@@ -172,8 +172,8 @@ export const useDBStore = create<DBState>((set, get) => ({
 
         // PAYMENT
         if (
-          m.payload.startsWith(PROTOCOL_PREFIX) &&
-          m.payload.includes(PAYMENT_PREFIX)
+          m.payload.startsWith(PROTOCOL.prefix.hex) &&
+          m.payload.includes(PROTOCOL.headers.PAYMENT.hex)
         ) {
           messageEntities.payments.push({
             amount: m.amount,

--- a/src/store/messaging.store.ts
+++ b/src/store/messaging.store.ts
@@ -24,7 +24,7 @@ import {
   ActiveConversation,
 } from "./repository/conversation.repository";
 import { loadLegacyMessages, saveMessages } from "../utils/storage-encryption";
-import { PROTOCOL_PREFIX, PAYMENT_PREFIX } from "../config/protocol";
+import { PROTOCOL } from "../config/protocol";
 import { Payment } from "./repository/payment.repository";
 import { Message } from "./repository/message.repository";
 import { Handshake } from "./repository/handshake.repository";
@@ -436,7 +436,10 @@ export const useMessagingStore = create<MessagingState>((set, g) => {
                 ),
                 createdAt: new Date(Number(newIndexerPayment.block_time)),
                 fee: 0,
-                payload: PROTOCOL_PREFIX + PAYMENT_PREFIX + decodedMessage,
+                payload:
+                  PROTOCOL.prefix.hex +
+                  PROTOCOL.headers.PAYMENT.hex +
+                  decodedMessage,
                 recipientAddress: address,
                 senderAddress: newIndexerPayment.sender,
                 transactionId: newIndexerPayment.tx_id,
@@ -547,7 +550,7 @@ export const useMessagingStore = create<MessagingState>((set, g) => {
 
         // HANDSHAKE
         if (
-          transaction.content.startsWith("ciph_msg:") &&
+          transaction.content.startsWith(PROTOCOL.prefix.string) &&
           transaction.content.includes(":handshake:")
         ) {
           try {
@@ -679,8 +682,8 @@ export const useMessagingStore = create<MessagingState>((set, g) => {
 
         // PAYMENT
         if (
-          transaction.payload.startsWith(PROTOCOL_PREFIX) &&
-          transaction.payload.includes(PAYMENT_PREFIX)
+          transaction.payload.startsWith(PROTOCOL.prefix.hex) &&
+          transaction.payload.includes(PROTOCOL.headers.PAYMENT.hex)
         ) {
           const payment: Payment = {
             __type: "payment",

--- a/src/store/wallet.store.ts
+++ b/src/store/wallet.store.ts
@@ -19,6 +19,7 @@ import {
 import { TransactionId } from "../types/transactions";
 import { PriorityFeeConfig } from "../types/all";
 import { FEE_ESTIMATE_POLLING_INTERVAL_IN_MS } from "../config/constants";
+import { PROTOCOL } from "../config/protocol";
 
 export interface WalletStoreSendMessageArgs {
   message: string;
@@ -340,7 +341,7 @@ export const useWalletStore = create<WalletState>((set, get) => {
       try {
         // Check if this is a handshake message
         if (
-          message.startsWith("ciph_msg:") &&
+          message.startsWith(PROTOCOL.prefix.string) &&
           message.includes(":handshake:")
         ) {
           // Always send handshake messages to the recipient's address

--- a/src/utils/cipher-helper.ts
+++ b/src/utils/cipher-helper.ts
@@ -6,6 +6,7 @@ import {
   PrivateKey,
 } from "cipher";
 import { SecurityHelper } from "./security-helper";
+import { PROTOCOL } from "src/config/protocol";
 
 /**
  * Helper functions for working with cipher encryption/decryption
@@ -169,7 +170,7 @@ export class CipherHelper {
    * @returns The hex string without prefix
    */
   static stripPrefix(payload: string): string {
-    const prefix = "ciph_msg:"
+    const prefix = PROTOCOL.prefix.string
       .split("")
       .map((c) => c.charCodeAt(0).toString(16).padStart(2, "0"))
       .join("");


### PR DESCRIPTION
## what?
this just refactors and centralizes the protocol prefix / headers.
aware its due to change with dcom, but this gives it some structure.

for review ease, i just modify `src/config/protocol.ts` and then propagate its use throughout the app.

[this card](https://github.com/K-Kluster/Kasia/issues/169)

**this has been rebased on indexeddb**

note: there is some double handling, like calling the string version of the protocol and then calling .hex. we can sort this out after rebase is finished.