### PR TITLE
feat:add featureflip system and functionality /3

### DIFF
--- a/src/components/MessageDisplay.tsx
+++ b/src/components/MessageDisplay.tsx
@@ -8,7 +8,7 @@ import clsx from "clsx";
 import { parseMessageForDisplay } from "../utils/message-format";
 import { Contact } from "../store/repository/contact.repository";
 import { Conversation } from "../store/repository/conversation.repository";
-import { PROTOCOL, DELIM } from "../config/protocol";
+import { PROTOCOL } from "../config/protocol";
 
 type MessageDisplayProps = {
   event: KasiaConversationEvent;

--- a/src/components/MessageDisplay.tsx
+++ b/src/components/MessageDisplay.tsx
@@ -8,7 +8,7 @@ import clsx from "clsx";
 import { parseMessageForDisplay } from "../utils/message-format";
 import { Contact } from "../store/repository/contact.repository";
 import { Conversation } from "../store/repository/conversation.repository";
-import { PROTOCOL } from "../config/protocol";
+import { PROTOCOL, DELIM } from "../config/protocol";
 
 type MessageDisplayProps = {
   event: KasiaConversationEvent;

--- a/src/components/Modals/SettingsModal.tsx
+++ b/src/components/Modals/SettingsModal.tsx
@@ -72,7 +72,7 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
   const changePassword = useWalletStore((s) => s.changePassword);
   const changeWalletName = useWalletStore((s) => s.changeWalletName);
   const networkStore = useNetworkStore();
-  const { flags, flips, setFlag, loadFlags } = useFeatureFlagsStore();
+  const { flags, flips, setFlag } = useFeatureFlagsStore();
 
   const tabs = [
     { id: "account", label: "Account", icon: User },
@@ -271,10 +271,6 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
     window.addEventListener("resize", checkIfMobile);
     return () => window.removeEventListener("resize", checkIfMobile);
   }, []);
-
-  useEffect(() => {
-    loadFlags();
-  }, [loadFlags]);
 
   // Real-time validation for wallet name
   useEffect(() => {

--- a/src/components/Modals/SettingsModal.tsx
+++ b/src/components/Modals/SettingsModal.tsx
@@ -80,7 +80,7 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
     { id: "network", label: "Network", icon: Network },
     { id: "security", label: "Security", icon: Shield },
     // only show if there are >0 flips
-    ...(flips.length > 0
+    ...(Object.keys(flips).length > 0
       ? [{ id: "extras", label: "Extras", icon: RectangleEllipsis }]
       : []),
   ];
@@ -843,9 +843,9 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
                     content
                   </div>
                 </div>
-                {flips.map((item) => (
+                {Object.entries(flips).map(([flagKey, item]) => (
                   <div
-                    key={item.id}
+                    key={flagKey}
                     className="border-primary-border bg-primary-bg my-2 rounded-2xl border p-4"
                   >
                     <div className="flex items-center justify-between">
@@ -858,15 +858,15 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
                         </div>
                       </div>
                       <Switch
-                        checked={flags[item.id] || false}
-                        onChange={(enabled) => setFlag(item.id, enabled)}
+                        checked={flags[flagKey as FeatureFlags] || false}
+                        onChange={(enabled) =>
+                          setFlag(flagKey as FeatureFlags, enabled)
+                        }
                         className={clsx(
                           "relative inline-flex h-6 w-11 cursor-pointer items-center rounded-full transition-colors",
                           {
-                            "bg-kas-secondary":
-                              flags[item.id as keyof FeatureFlags],
-                            "bg-gray-300":
-                              !flags[item.id as keyof FeatureFlags],
+                            "bg-kas-secondary": flags[flagKey as FeatureFlags],
+                            "bg-gray-300": !flags[flagKey as FeatureFlags],
                           }
                         )}
                       >
@@ -874,10 +874,8 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
                           className={clsx(
                             "inline-block h-4 w-4 transform rounded-full bg-white transition-transform",
                             {
-                              "translate-x-6":
-                                flags[item.id as keyof FeatureFlags],
-                              "translate-x-1":
-                                !flags[item.id as keyof FeatureFlags],
+                              "translate-x-6": flags[flagKey as FeatureFlags],
+                              "translate-x-1": !flags[flagKey as FeatureFlags],
                             }
                           )}
                         />

--- a/src/store/featureflag.store.ts
+++ b/src/store/featureflag.store.ts
@@ -38,27 +38,28 @@ const useFeatureFlagsStore = create<{
   flags: FeatureFlags;
   flips: FeatureFlip[];
   setFlag: (key: keyof FeatureFlags, value: boolean) => void;
-  loadFlags: () => void;
-}>((set, get) => ({
-  flags: defaultFlags,
-  flips: featureFlips,
+}>((set, get) => {
+  // hydrate features here, else take default value
+  let initialFlags = defaultFlags;
+  try {
+    const stored = JSON.parse(
+      localStorage.getItem("kasia-feature-flags") || "{}"
+    );
+    initialFlags = { ...defaultFlags, ...stored };
+  } catch {
+    console.error("Invalid flags in localStorage");
+  }
 
-  setFlag: (key, value) => {
-    const updated = { ...get().flags, [key]: value };
-    set({ flags: updated });
-    localStorage.setItem("kasia-feature-flags", JSON.stringify(updated));
-  },
+  return {
+    flags: initialFlags,
+    flips: featureFlips,
 
-  loadFlags: () => {
-    try {
-      const stored = JSON.parse(
-        localStorage.getItem("kasia-feature-flags") || "{}"
-      );
-      set({ flags: { ...defaultFlags, ...stored } });
-    } catch {
-      console.error("Invalid flags in localStorage");
-    }
-  },
-}));
+    setFlag: (key, value) => {
+      const updated = { ...get().flags, [key]: value };
+      set({ flags: updated });
+      localStorage.setItem("kasia-feature-flags", JSON.stringify(updated));
+    },
+  };
+});
 
 export { useFeatureFlagsStore };

--- a/src/store/featureflag.store.ts
+++ b/src/store/featureflag.store.ts
@@ -1,51 +1,44 @@
 import { create } from "zustand";
 import { Dices, LucideIcon } from "lucide-react";
 
-export interface FeatureFlags {
-  gameframe: boolean;
-  moreitems: boolean;
+export enum FeatureFlags {
+  GAME_FRAME = "gameframe",
 }
 
-export interface FeatureFlip {
-  id: keyof FeatureFlags;
+export type FeatureFlagsTable = Record<FeatureFlags, boolean>;
+
+const defaultFeatureFlagsTable: FeatureFlagsTable = {
+  [FeatureFlags.GAME_FRAME]: false,
+};
+
+export interface FeatureDescription {
   label: string;
   desc: string;
   icon: LucideIcon;
 }
 
-const defaultFlags: FeatureFlags = {
-  gameframe: false,
-  moreitems: false,
+export type FeatureFlips = Record<FeatureFlags, FeatureDescription>;
+
+const featureFlips: FeatureFlips = {
+  [FeatureFlags.GAME_FRAME]: {
+    label: "Game Frame",
+    desc: "NOT IMPLEMENTED - JUST FOR FLAG DEMO.",
+    icon: Dices,
+  },
 };
 
-const featureFlips: FeatureFlip[] = [
-  // UNCOMMENT BELOW!
-  // {
-  //   id: "gameframe",
-  //   label: "Game Frame",
-  //   desc: "This enables external game frame content. NOT IMPLEMENTED - JUST FOR FLAG DEMO.",
-  //   icon: Dices,
-  // },
-  // {
-  //   id: "moreitems",
-  //   label: "More Items",
-  //   desc: "This would be something else!",
-  //   icon: Dices,
-  //},
-];
-
 const useFeatureFlagsStore = create<{
-  flags: FeatureFlags;
-  flips: FeatureFlip[];
-  setFlag: (key: keyof FeatureFlags, value: boolean) => void;
+  flags: FeatureFlagsTable;
+  flips: FeatureFlips;
+  setFlag: (key: FeatureFlags, value: boolean) => void;
 }>((set, get) => {
   // hydrate features here, else take default value
-  let initialFlags = defaultFlags;
+  let initialFlags = defaultFeatureFlagsTable;
   try {
     const stored = JSON.parse(
       localStorage.getItem("kasia-feature-flags") || "{}"
     );
-    initialFlags = { ...defaultFlags, ...stored };
+    initialFlags = { ...defaultFeatureFlagsTable, ...stored };
   } catch {
     console.error("Invalid flags in localStorage");
   }

--- a/src/store/featureflag.store.ts
+++ b/src/store/featureflag.store.ts
@@ -1,0 +1,64 @@
+import { create } from "zustand";
+import { Dices, LucideIcon } from "lucide-react";
+
+export interface FeatureFlags {
+  gameframe: boolean;
+  moreitems: boolean;
+}
+
+export interface FeatureFlip {
+  id: keyof FeatureFlags;
+  label: string;
+  desc: string;
+  icon: LucideIcon;
+}
+
+const defaultFlags: FeatureFlags = {
+  gameframe: false,
+  moreitems: false,
+};
+
+const featureFlips: FeatureFlip[] = [
+  // UNCOMMENT BELOW!
+  // {
+  //   id: "gameframe",
+  //   label: "Game Frame",
+  //   desc: "This enables external game frame content. NOT IMPLEMENTED - JUST FOR FLAG DEMO.",
+  //   icon: Dices,
+  // },
+  // {
+  //   id: "moreitems",
+  //   label: "More Items",
+  //   desc: "This would be something else!",
+  //   icon: Dices,
+  //},
+];
+
+const useFeatureFlagsStore = create<{
+  flags: FeatureFlags;
+  flips: FeatureFlip[];
+  setFlag: (key: keyof FeatureFlags, value: boolean) => void;
+  loadFlags: () => void;
+}>((set, get) => ({
+  flags: defaultFlags,
+  flips: featureFlips,
+
+  setFlag: (key, value) => {
+    const updated = { ...get().flags, [key]: value };
+    set({ flags: updated });
+    localStorage.setItem("kasia-feature-flags", JSON.stringify(updated));
+  },
+
+  loadFlags: () => {
+    try {
+      const stored = JSON.parse(
+        localStorage.getItem("kasia-feature-flags") || "{}"
+      );
+      set({ flags: { ...defaultFlags, ...stored } });
+    } catch {
+      console.error("Invalid flags in localStorage");
+    }
+  },
+}));
+
+export { useFeatureFlagsStore };


### PR DESCRIPTION
## what?
this adds a user feature flip system to the settings modal menu
currently stores status in local storage. potentially will migrate to indexeddb later too.

note 1.a: there's nothing in the store atm, there are 2 'example' flags in the `src/store/featureflag.store.ts` store.
note1.b: you *will* need to comment these out to test this pr.

2 open questions:
also not sure if we should have a flag set *per wallet* or just generally for the account?
not sure if I should move this from extras tab to the account settings?

^potentially it could be unified with theme under `settings-{wallet}` but ill wait for indexeddb for that

**this has been rebased on indexeddb**
 
