### PR TITLE
refactor: message input in chat /8

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,10 @@ For VsCode user, this is automatically done through .vscode workspace settings.
 
 We use React 19 with React Compiler - as long as you follow the [rules of hooks](https://react.dev/reference/rules/rules-of-hooks) - there is no need to optimize code.
 
+Use the store directly for pure state updates. If there are side effects, route them through a hook instead.
+Use one hook per store for simple cases.
+For more complex scenarios involving multiple stores and hooks, considering creating a manager hook that wraps the individual ones.
+
 ### Web style
 
 For any new implementations, we enforce the use of inline TailwindCSS. A well-known utility `clsx` is available within the codebase for more conplex style application (e.g.: conditional style)

--- a/src/components/Layout/ModalHost.tsx
+++ b/src/components/Layout/ModalHost.tsx
@@ -104,7 +104,7 @@ export const ModalHost = () => {
         </Modal>
       )}
 
-      {/* Warning Costly Send Message Modal (previously in SendMessageForm) */}
+      {/* Warning Costly Send Message Modal */}
       {modals["warn-costy-send-message"] && (
         <Modal onClose={() => closeModal("warn-costy-send-message")}>
           <div className="flex flex-col items-center justify-center gap-8">

--- a/src/components/MessageComposer/AttachmentBasic.tsx
+++ b/src/components/MessageComposer/AttachmentBasic.tsx
@@ -1,0 +1,52 @@
+import { Paperclip, Trash2 } from "lucide-react";
+import {
+  useComposerSlice,
+  useComposerStore,
+} from "../../store/message-composer.store";
+import { MESSAGE_COMPOSER_MAX_HEIGHT } from "../../config/constants";
+
+// this component is for rendering either a file or an image when its been attached
+// also adds a trash button to delete
+// further refactoring could ofc happen, but its good enough for now
+export const AttachmentBasic = () => {
+  // query the store for attachment
+  const attachment = useComposerSlice((s) => s.attachment);
+  const setAttachment = useComposerStore((s) => s.setAttachment);
+
+  const removeAttachment = () => {
+    setAttachment(null);
+  };
+
+  return (
+    <>
+      {attachment && (
+        <div
+          className={`bg-primary-bg border-secondary-border relative box-border flex-1 resize-none rounded-3xl border py-3 pr-20 pl-4 max-h-[${MESSAGE_COMPOSER_MAX_HEIGHT}px] overflow-hidden`}
+        >
+          <div className="flex items-center justify-between gap-2">
+            {attachment.type === "image" ? (
+              <img
+                src={JSON.parse(attachment.data).content}
+                alt={attachment.name}
+                className="block max-h-[120px] max-w-[200px] flex-1 rounded-lg object-contain"
+              />
+            ) : (
+              <div className="flex items-center gap-2 text-sm">
+                <Paperclip className="h-4 w-4" />
+                {attachment.name} (
+                {Math.round((JSON.parse(attachment.data).size || 0) / 1024)}KB)
+              </div>
+            )}
+            <button
+              onClick={removeAttachment}
+              className="flex-shrink-0 cursor-pointer rounded-full p-1 text-[var(--accent-red)] transition-colors duration-200 hover:text-[var(--accent-red)]/80"
+              title="Remove attachment"
+            >
+              <Trash2 className="size-6" />
+            </button>
+          </div>
+        </div>
+      )}
+    </>
+  );
+};

--- a/src/components/MessageComposer/FeeDisplay.tsx
+++ b/src/components/MessageComposer/FeeDisplay.tsx
@@ -1,0 +1,69 @@
+import clsx from "clsx";
+import { formatKasAmount } from "../../utils/format";
+import { PriorityFeeSelector } from "../PriorityFeeSelector";
+import { PriorityFeeConfig } from "../../types/all";
+
+// fee levels for color coding
+// need to extract this and make it setable from the settings
+const FEE_LEVELS = [
+  { limit: 0.00002, classes: "text-green-400 border-green-400" },
+  { limit: 0.00005, classes: "text-blue-400  border-blue-400" },
+  { limit: 0.0005, classes: "text-yellow-400 border-yellow-400" },
+  { limit: 0.001, classes: "text-orange-400 border-orange-400" },
+  { limit: Infinity, classes: "text-red-400 border-red-400" },
+];
+
+function getFeeClasses(fee: number) {
+  return FEE_LEVELS.find(({ limit }) => fee <= limit)!.classes;
+}
+
+interface FeeDisplayProps {
+  recipient?: string;
+  draft: string;
+  feeState: {
+    status: "idle" | "loading" | "error";
+    error?: Error;
+    value?: number;
+  };
+  priority: PriorityFeeConfig;
+  onPriorityChange: (priority: PriorityFeeConfig) => void;
+}
+
+// this displayes the fee above the message box and colors it!
+export const FeeDisplay = ({
+  recipient,
+  draft,
+  feeState,
+  priority,
+  onPriorityChange,
+}: FeeDisplayProps) => {
+  // only show fee display when we have a recipient and draft
+  if (!recipient || !draft) {
+    return null;
+  }
+
+  return (
+    <div className="absolute -top-7.5 right-4 flex items-center gap-2">
+      <div
+        className={clsx(
+          "inline-block rounded-md border bg-white/10 px-3 py-1 text-right text-xs text-gray-400 transition-opacity duration-300 ease-out",
+          feeState.value && getFeeClasses(feeState.value)
+        )}
+      >
+        {feeState.status === "loading"
+          ? feeState.value != null
+            ? `Updating fee… ${formatKasAmount(feeState.value)} KAS`
+            : "Estimating fee…"
+          : feeState.value != null
+            ? `Estimated fee: ${formatKasAmount(feeState.value)} KAS`
+            : "Calculating fee…"}
+      </div>
+
+      <PriorityFeeSelector
+        currentFee={priority}
+        onFeeChange={onPriorityChange}
+        className="mr-0 sm:mr-2"
+      />
+    </div>
+  );
+};

--- a/src/components/MessageComposer/InputBasic.tsx
+++ b/src/components/MessageComposer/InputBasic.tsx
@@ -1,4 +1,4 @@
-import { RefObject, useEffect, useState, useRef, forwardRef } from "react";
+import { useEffect, useState, forwardRef } from "react";
 import clsx from "clsx";
 import {
   MESSAGE_COMPOSER_MIN_HEIGHT,

--- a/src/components/MessageComposer/InputBasic.tsx
+++ b/src/components/MessageComposer/InputBasic.tsx
@@ -1,0 +1,104 @@
+import { RefObject, useEffect, useState, useRef, forwardRef } from "react";
+import clsx from "clsx";
+import {
+  MESSAGE_COMPOSER_MIN_HEIGHT,
+  MESSAGE_COMPOSER_MAX_HEIGHT,
+} from "../../config/constants";
+
+interface InputBasicProps {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  disabled?: boolean;
+  onSend?: () => void;
+  onKeyDown?: (e: React.KeyboardEvent) => void;
+  onPaste?: (e: React.ClipboardEvent<HTMLTextAreaElement>) => void;
+  className?: string;
+  onDragOver?: boolean;
+}
+
+// this is our "basic" input
+// it does have added complexity for managing its height, max height and over / pasting etc
+// but its simple incomparison to a potential rich text editor
+export const InputBasic = forwardRef<HTMLTextAreaElement, InputBasicProps>(
+  (
+    {
+      value,
+      onChange,
+      placeholder,
+      disabled,
+      onSend,
+      onKeyDown,
+      onPaste,
+      className,
+      onDragOver,
+    },
+    ref
+  ) => {
+    const [textareaHeight, setTextareaHeight] = useState(
+      MESSAGE_COMPOSER_MIN_HEIGHT
+    );
+    const [showScroll, setShowScroll] = useState(false);
+
+    const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+      onChange(e.target.value);
+
+      // auto-resize logic - measure with minimal height
+      const originalHeight = e.target.style.height;
+      e.target.style.height = "1px";
+      const scrollHeight = e.target.scrollHeight;
+      e.target.style.height = originalHeight;
+
+      // add padding compensation
+      const contentHeight = scrollHeight + 0;
+      const newHeight = Math.max(
+        MESSAGE_COMPOSER_MIN_HEIGHT,
+        Math.min(contentHeight, MESSAGE_COMPOSER_MAX_HEIGHT)
+      );
+
+      setTextareaHeight(newHeight);
+      // set scroll when content needs more than 144px
+      setShowScroll(contentHeight > MESSAGE_COMPOSER_MAX_HEIGHT);
+    };
+
+    // reset height when content becomes empty
+    useEffect(() => {
+      if (!value) {
+        setTextareaHeight(MESSAGE_COMPOSER_MIN_HEIGHT);
+        setShowScroll(false);
+
+        // auto-focus when input becomes empty (after send)
+        if (ref && typeof ref !== "function" && ref.current) {
+          ref.current.focus();
+        }
+      }
+    }, [value, ref]);
+
+    const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if (e.key === "Enter" && !e.shiftKey) {
+        e.preventDefault();
+        onSend?.();
+      }
+      onKeyDown?.(e);
+    };
+
+    return (
+      <textarea
+        ref={ref}
+        value={value}
+        onChange={handleChange}
+        onKeyDown={handleKeyDown}
+        onPaste={onPaste}
+        placeholder={placeholder}
+        disabled={disabled}
+        className={clsx(
+          className ||
+            "peer bg-primary-bg box-border flex-1 resize-none rounded-3xl py-3 pr-20 pl-4 text-sm text-[var(--text-primary)]",
+          showScroll ? "overflow-y-auto" : "overflow-y-hidden",
+          onDragOver ? "border-kas-secondary border" : "outline-none"
+        )}
+        style={{ height: `${textareaHeight}px` }}
+      />
+    );
+  }
+);

--- a/src/components/MessageComposer/MessageComposerShell.tsx
+++ b/src/components/MessageComposer/MessageComposerShell.tsx
@@ -1,0 +1,255 @@
+import { useRef, useState, DragEvent, useEffect } from "react";
+import {
+  useComposerSlice,
+  useComposerStore,
+} from "../../store/message-composer.store";
+import { useMessageComposer } from "../../hooks/MessageComposer/useMessageComposer";
+import { SendHorizonal, Paperclip, Camera, Plus } from "lucide-react";
+import clsx from "clsx";
+import {
+  Popover,
+  PopoverButton,
+  PopoverPanel,
+  Transition,
+} from "@headlessui/react";
+import { SendPaymentPopup } from "../SendPaymentPopup";
+import { MessageInput } from "./MessageInput";
+import { FeeDisplay } from "./FeeDisplay";
+
+interface MessageComposerShellProps {
+  recipient?: string;
+  onExpand?: () => void;
+}
+
+export const MessageComposerShell = ({
+  recipient,
+}: MessageComposerShellProps) => {
+  const draft = useComposerSlice((s) => s.draft);
+  const attachment = useComposerSlice((s) => s.attachment);
+  const feeState = useComposerSlice((s) => s.feeState);
+  const sendState = useComposerSlice((s) => s.sendState);
+  const priority = useComposerSlice((s) => s.priority);
+
+  const messageInputRef = useRef<HTMLTextAreaElement | null>(null);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const cameraInputRef = useRef<HTMLInputElement | null>(null);
+
+  const { send, attach } = useMessageComposer(recipient);
+  const setDraft = useComposerStore((s) => s.setDraft);
+  const setPriority = useComposerStore((s) => s.setPriority);
+  const setSendState = useComposerStore((s) => s.setSendState);
+
+  const [isDragOver, setIsDragOver] = useState(false);
+  const [hasCamera, setHasCamera] = useState(false);
+
+  // check if a camera exists
+  useEffect(() => {
+    async function checkCamera() {
+      if (navigator.mediaDevices && navigator.mediaDevices.enumerateDevices) {
+        try {
+          const devices = await navigator.mediaDevices.enumerateDevices();
+          const hasVideoInput = devices.some(
+            (device) => device.kind === "videoinput"
+          );
+          setHasCamera(hasVideoInput);
+        } catch {
+          setHasCamera(false);
+        }
+      } else {
+        setHasCamera(false);
+      }
+    }
+    checkCamera();
+  }, []);
+
+  const openFileDialog = () => fileInputRef.current?.click();
+  const openCameraDialog = () => cameraInputRef.current?.click();
+
+  const handleFileUpload = async (
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+    await attach(file, "File");
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  };
+
+  const handlePaste = async (
+    event: React.ClipboardEvent<HTMLTextAreaElement>
+  ) => {
+    const items = event.clipboardData?.items;
+    if (!items) return;
+
+    for (let i = 0; i < items.length; i++) {
+      const item = items[i];
+      if (item.type.startsWith("image/")) {
+        event.preventDefault();
+        const file = item.getAsFile();
+        if (file) {
+          await attach(file, "Pasted Image");
+        }
+        break;
+      }
+    }
+  };
+
+  const handleDragOver = (e: DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsDragOver(true);
+  };
+
+  const handleDragLeave = (e: DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsDragOver(false);
+  };
+
+  const handleDrop = async (e: DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsDragOver(false);
+
+    const files = Array.from(e.dataTransfer.files);
+    if (files.length > 0) {
+      await attach(files[0], "Dropped File");
+    }
+  };
+
+  // clear error state when user starts typing
+  const handleDraftChange = (value: string) => {
+    setDraft(value);
+    // clear error state when user starts typing
+    if (sendState.status === "error") {
+      setSendState({ status: "idle" });
+    }
+  };
+
+  return (
+    <div
+      className={clsx(
+        "border-primary-border bg-secondary-bg relative flex-col gap-8 border-t transition-colors duration-200",
+        isDragOver && "border-kas-primary bg-kas-primary/10"
+      )}
+      onDragOver={handleDragOver}
+      onDragLeave={handleDragLeave}
+      onDrop={handleDrop}
+    >
+      {/* fee display - positioned in top-right like original */}
+      <FeeDisplay
+        recipient={recipient}
+        draft={draft}
+        feeState={feeState}
+        priority={priority}
+        onPriorityChange={setPriority}
+      />
+
+      {/* input area */}
+      <div className="relative my-2 mr-2 rounded-lg p-1 pb-3 sm:pb-0">
+        <div className="relative flex items-center">
+          <div className="relative flex h-10 w-10 flex-shrink-0 items-center justify-center">
+            <Popover className="relative">
+              {({ close }) => (
+                <>
+                  <PopoverButton className="rounded p-1 hover:bg-white/5">
+                    <Plus className="size-6 cursor-pointer text-[var(--button-primary)]" />
+                  </PopoverButton>
+                  <Transition
+                    enter="transition ease-out duration-100"
+                    enterFrom="opacity-0 translate-y-1"
+                    enterTo="opacity-100 translate-y-0"
+                    leave="transition ease-in duration-75"
+                    leaveFrom="opacity-100 translate-y-0"
+                    leaveTo="opacity-0 translate-y-1"
+                  >
+                    <PopoverPanel className="bg-secondary-bg absolute bottom-full left-0 mb-2 flex flex-col gap-2 rounded p-2 shadow-lg">
+                      <button
+                        onClick={() => {
+                          openFileDialog();
+                          close();
+                        }}
+                        className="flex cursor-pointer items-center gap-2 rounded p-2 hover:bg-white/5"
+                      >
+                        <Paperclip className="m-2 size-5" />
+                      </button>
+                      {recipient && (
+                        <SendPaymentPopup
+                          address={recipient}
+                          onPaymentSent={close}
+                        />
+                      )}
+                    </PopoverPanel>
+                  </Transition>
+                </>
+              )}
+            </Popover>
+          </div>
+
+          <MessageInput
+            ref={messageInputRef}
+            value={draft}
+            onChange={handleDraftChange} // Use our new handler instead of setDraft directly
+            onDragOver={isDragOver}
+            onSend={send}
+            onPaste={handlePaste}
+            placeholder="Type your message..."
+            disabled={sendState.status === "loading"}
+          />
+
+          {/* send button */}
+          <div className="absolute right-2 flex h-full items-center gap-1">
+            <div className="relative flex h-10 w-10 flex-shrink-0 items-center justify-center">
+              <div className="absolute inset-0 flex items-center justify-center">
+                <button
+                  onClick={() => {
+                    send();
+                  }}
+                  className={clsx(
+                    "absolute flex h-6 w-6 cursor-pointer items-center justify-center text-[var(--button-primary)] transition-all duration-200 ease-in-out hover:text-[var(--button-primary)]/80",
+                    draft.trim() || attachment
+                      ? "pointer-events-auto translate-x-0 opacity-100"
+                      : "pointer-events-none translate-x-4 opacity-0"
+                  )}
+                  aria-label="Send"
+                >
+                  <SendHorizonal className="size-6" />
+                </button>
+                {hasCamera && (
+                  <button
+                    onClick={openCameraDialog}
+                    className={clsx(
+                      "absolute flex h-6 w-6 cursor-pointer items-center justify-center text-[var(--button-primary)] transition-all duration-200 ease-in-out hover:text-[var(--button-primary)]/80",
+                      !draft.trim() && !attachment
+                        ? "pointer-events-auto translate-x-0 opacity-100"
+                        : "pointer-events-none -translate-x-4 opacity-0"
+                    )}
+                    aria-label="Open Camera"
+                  >
+                    <Camera className="size-6" />
+                  </button>
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* hidden file inputs */}
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="*/*"
+        onChange={handleFileUpload}
+        className="hidden"
+      />
+      <input
+        ref={cameraInputRef}
+        type="file"
+        accept="image/*"
+        capture="environment"
+        onChange={handleFileUpload}
+        className="hidden"
+      />
+    </div>
+  );
+};

--- a/src/components/MessageComposer/MessageComposerShell.tsx
+++ b/src/components/MessageComposer/MessageComposerShell.tsx
@@ -24,18 +24,21 @@ interface MessageComposerShellProps {
 export const MessageComposerShell = ({
   recipient,
 }: MessageComposerShellProps) => {
-  const draft = useComposerSlice((s) => s.draft);
   const attachment = useComposerSlice((s) => s.attachment);
   const feeState = useComposerSlice((s) => s.feeState);
   const sendState = useComposerSlice((s) => s.sendState);
   const priority = useComposerSlice((s) => s.priority);
+  const setDraft = useComposerStore((s) => s.setDraft);
+
+  const draft = useComposerSlice((s) =>
+    recipient ? s.drafts[recipient] || "" : ""
+  );
 
   const messageInputRef = useRef<HTMLTextAreaElement | null>(null);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const cameraInputRef = useRef<HTMLInputElement | null>(null);
 
   const { send, attach } = useMessageComposer(recipient);
-  const setDraft = useComposerStore((s) => s.setDraft);
   const setPriority = useComposerStore((s) => s.setPriority);
   const setSendState = useComposerStore((s) => s.setSendState);
 
@@ -118,7 +121,9 @@ export const MessageComposerShell = ({
 
   // clear error state when user starts typing
   const handleDraftChange = (value: string) => {
-    setDraft(value);
+    if (recipient) {
+      setDraft(recipient, value);
+    }
     // clear error state when user starts typing
     if (sendState.status === "error") {
       setSendState({ status: "idle" });

--- a/src/components/MessageComposer/MessageInput.tsx
+++ b/src/components/MessageComposer/MessageInput.tsx
@@ -1,0 +1,28 @@
+import { forwardRef } from "react";
+import { InputBasic } from "./InputBasic";
+import { AttachmentBasic } from "./AttachmentBasic";
+import { useComposerSlice } from "../../store/message-composer.store";
+
+interface MessageInputProps {
+  value: string;
+  onChange: (value: string) => void;
+  onSend?: () => void;
+  onPaste?: (e: React.ClipboardEvent<HTMLTextAreaElement>) => void;
+  onDragOver: boolean;
+  placeholder?: string;
+  disabled?: boolean;
+  className?: string;
+}
+
+export const MessageInput = forwardRef<HTMLTextAreaElement, MessageInputProps>(
+  ({ ...props }, ref) => {
+    const attachment = useComposerSlice((s) => s.attachment);
+
+    // if there's an attachment, show its preview, otherwise show input with ref
+    return (
+      <>
+        {attachment ? <AttachmentBasic /> : <InputBasic {...props} ref={ref} />}
+      </>
+    );
+  }
+);

--- a/src/components/SendPaymentPopup.tsx
+++ b/src/components/SendPaymentPopup.tsx
@@ -235,14 +235,14 @@ export const SendPaymentPopup: FC<{
   // Check if user can send messages with payments (now simplified - no conversation required)
   const canSendMessageWithPayment = true; // Anyone can send payment messages now
 
-  const useInputRef = useCallback(
-    (node: HTMLInputElement | null) => {
-      if (node && panelOpen) {
-        node.focus();
-      }
-    },
-    [panelOpen]
-  );
+  const amountInputRef = useRef<HTMLInputElement | null>(null);
+
+  // focus amount input when panel opens
+  useEffect(() => {
+    if (panelOpen && amountInputRef.current) {
+      amountInputRef.current.focus();
+    }
+  }, [panelOpen]);
 
   return (
     <div className="relative">
@@ -301,7 +301,7 @@ export const SendPaymentPopup: FC<{
               <div className="w-full flex-1">
                 <div className="relative">
                   <Input
-                    ref={useInputRef}
+                    ref={amountInputRef}
                     type="text"
                     value={payAmount}
                     onChange={(e) => handlePayAmountChange(e.target.value)}

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -34,3 +34,9 @@ export const DEFAULT_FEE_BUCKETS: FeeBucket[] = [
     amount: BigInt(10000), // 0.0001 KAS (fallback)
   },
 ];
+
+// message composer height constants
+export const MESSAGE_COMPOSER_MIN_HEIGHT = 47;
+export const MESSAGE_COMPOSER_MAX_ROWS = 3;
+export const MESSAGE_COMPOSER_MAX_HEIGHT =
+  MESSAGE_COMPOSER_MIN_HEIGHT * MESSAGE_COMPOSER_MAX_ROWS;

--- a/src/containers/MessagesSection.tsx
+++ b/src/containers/MessagesSection.tsx
@@ -3,7 +3,7 @@ import { ChevronLeft } from "lucide-react";
 import { Pencil, Info, Copy, Check, UserCog } from "lucide-react";
 import { FetchApiMessages } from "../components/FetchApiMessages";
 import { MessagesList } from "../components/MessagesList";
-import { SendMessageForm } from "./SendMessageForm";
+import { MessageComposerShell } from "../components/MessageComposer/MessageComposerShell";
 import { useMessagingStore } from "../store/messaging.store";
 import { useWalletStore } from "../store/wallet.store";
 import { KaspaAddress } from "../components/KaspaAddress";
@@ -442,7 +442,10 @@ export const MessageSection: FC<{
               lastIncoming={lastIncoming}
             />
           </div>
-          <SendMessageForm onExpand={scrollToBottom} />
+          <MessageComposerShell
+            recipient={openedRecipient || undefined}
+            onExpand={scrollToBottom}
+          />
         </>
       )}
 

--- a/src/containers/SendMessageForm.tsx
+++ b/src/containers/SendMessageForm.tsx
@@ -40,6 +40,9 @@ type SendMessageFormProps = {
   onExpand?: () => void;
 };
 
+const REMINDER =
+  " rebased originally I had deleted `SendMessageForm` but the indexeddb has some changes to it (that I will need to migrate to the new files). I will do this once we are at parity with staging.**";
+
 // Arbritary fee levels to colour the fee indicator in chat
 const FEE_LEVELS = [
   { limit: 0.00002, classes: "text-green-400 border-green-400" },

--- a/src/hooks/MessageComposer/useFeeEstimate.ts
+++ b/src/hooks/MessageComposer/useFeeEstimate.ts
@@ -4,8 +4,12 @@ import { useWalletStore } from "../../store/wallet.store";
 import { Address } from "kaspa-wasm";
 
 export const useFeeEstimate = (recipient?: string) => {
-  const { draft, priority, sendState, setFeeState } = useComposerStore();
+  const { priority, sendState, setFeeState } = useComposerStore();
   const walletStore = useWalletStore();
+
+  const draft = useComposerStore((s) =>
+    recipient ? s.drafts[recipient] || "" : ""
+  );
 
   useEffect(() => {
     if (

--- a/src/hooks/MessageComposer/useFeeEstimate.ts
+++ b/src/hooks/MessageComposer/useFeeEstimate.ts
@@ -1,0 +1,48 @@
+import { useEffect } from "react";
+import { useComposerStore } from "../../store/message-composer.store";
+import { useWalletStore } from "../../store/wallet.store";
+import { Address } from "kaspa-wasm";
+
+export const useFeeEstimate = (recipient?: string) => {
+  const { draft, priority, sendState, setFeeState } = useComposerStore();
+  const walletStore = useWalletStore();
+
+  useEffect(() => {
+    if (
+      !recipient ||
+      !draft ||
+      !walletStore.unlockedWallet ||
+      sendState.status === "loading"
+    ) {
+      setFeeState({ status: "idle" });
+      return;
+    }
+
+    setFeeState({ status: "loading" });
+
+    // debounce the fee estimation
+    const timeoutId = setTimeout(() => {
+      walletStore
+        .estimateSendMessageFees(draft, new Address(recipient), priority)
+        .then((estimate) => {
+          const fee = Number(estimate.fees) / 100_000_000;
+          setFeeState({ status: "idle", value: fee });
+        })
+        .catch((error) => {
+          setFeeState({ status: "error", error: error as Error });
+        });
+    }, 400);
+
+    return () => {
+      clearTimeout(timeoutId);
+    };
+  }, [
+    draft,
+    recipient,
+    priority,
+    sendState.status,
+    walletStore.unlockedWallet,
+    setFeeState,
+    walletStore,
+  ]);
+};

--- a/src/hooks/MessageComposer/useMessageComposer.ts
+++ b/src/hooks/MessageComposer/useMessageComposer.ts
@@ -1,0 +1,157 @@
+import { useComposerStore } from "../../store/message-composer.store";
+import { useWalletStore } from "../../store/wallet.store";
+import { useMessagingStore } from "../../store/messaging.store";
+import { Address } from "kaspa-wasm";
+import { toast } from "../../utils/toast-helper";
+import { unknownErrorToErrorLike } from "../../utils/errors";
+import { useFeeEstimate } from "./useFeeEstimate";
+import { Message } from "../../types/all";
+import { prepareFileForUpload } from "../../service/upload-file-service";
+import { MAX_PAYLOAD_SIZE } from "../../config/constants";
+
+export const useMessageComposer = (recipient?: string) => {
+  const {
+    draft,
+    attachment,
+    priority,
+    sendState,
+    reset,
+    setSendState,
+    feeState,
+    setAttachment,
+  } = useComposerStore();
+  const walletStore = useWalletStore();
+  const messageStore = useMessagingStore();
+
+  const attach = async (file: File, source: string = "File") => {
+    const { fileMessage, error } = await prepareFileForUpload(
+      file,
+      MAX_PAYLOAD_SIZE,
+      {},
+      (status) => {
+        toast.info(status);
+      }
+    );
+
+    if (error) {
+      toast.error(error);
+      return;
+    }
+
+    if (fileMessage) {
+      const typedAttachment = {
+        type: file.type.startsWith("image/")
+          ? ("image" as const)
+          : ("file" as const),
+        name: file.name,
+        mime: file.type,
+        data: fileMessage,
+        size: file.size,
+      };
+
+      setAttachment(typedAttachment);
+      toast.success(`Attached ${source.toLowerCase()} successfully!`);
+    }
+  };
+
+  const send = async () => {
+    // check recipient first
+    if (!recipient) {
+      toast.error("Error, please select a contact.");
+      return;
+    }
+
+    // check wallet unlock status
+    if (!walletStore.unlockedWallet) {
+      toast.error("Error, reload app.");
+      return;
+    }
+
+    // check wallet address
+    if (!walletStore.address) {
+      toast.error(
+        "No wallet address found. Please check your wallet connection."
+      );
+      return;
+    }
+
+    // check if there's content to send
+    if (!draft && !attachment) {
+      toast.error("Please enter a message or attach a file.");
+      return;
+    }
+
+    // check fee estimation status
+    if (feeState.status === "error") {
+      toast.error("Fee estimation failed. Please try again or reload the app.");
+      return;
+    }
+
+    // check if already sending
+    if (sendState.status === "loading") {
+      return;
+    }
+
+    setSendState({ status: "loading" });
+    try {
+      let messageToSend = draft;
+      let fileDataForStorage = null;
+
+      if (attachment) {
+        try {
+          const parsedData = JSON.parse(attachment.data);
+          messageToSend = attachment.data; // Send the full JSON, not just content
+          fileDataForStorage = {
+            type: parsedData.type,
+            name: parsedData.name,
+            size: parsedData.size,
+            mimeType: parsedData.mimeType,
+            content: parsedData.content,
+          };
+        } catch (error) {
+          console.error("Error parsing attachment data:", error);
+          messageToSend = draft;
+        }
+      }
+
+      const txId = await walletStore.sendMessage({
+        message: messageToSend,
+        toAddress: new Address(recipient),
+        password: walletStore.unlockedWallet.password,
+        priorityFee: priority,
+      });
+
+      const newMessageData: Message = {
+        transactionId: txId,
+        senderAddress: walletStore.address.toString(),
+        recipientAddress: recipient,
+        timestamp: Date.now(),
+        content: fileDataForStorage
+          ? JSON.stringify(fileDataForStorage)
+          : draft,
+        amount: 20000000, // 0.2 KAS in sompi
+        fee: feeState.value || undefined,
+        payload: "",
+        fileData: fileDataForStorage || undefined,
+      };
+
+      // store message under both sender and recipient addresses for proper conversation grouping
+      messageStore.storeMessage(newMessageData, walletStore.address.toString());
+      messageStore.storeMessage(newMessageData, recipient);
+      messageStore.addMessages([newMessageData]);
+
+      // keep the conversation open with the same recipient
+      messageStore.setOpenedRecipient(recipient);
+
+      reset();
+    } catch (error) {
+      console.error("Error sending message:", error);
+      setSendState({ status: "error", error: error as Error });
+      toast.error(`Failed to send message: ${unknownErrorToErrorLike(error)}`);
+    }
+  };
+
+  useFeeEstimate(recipient);
+
+  return { send, attach };
+};

--- a/src/hooks/MessageComposer/useMessageComposer.ts
+++ b/src/hooks/MessageComposer/useMessageComposer.ts
@@ -11,15 +11,18 @@ import { MAX_PAYLOAD_SIZE } from "../../config/constants";
 
 export const useMessageComposer = (recipient?: string) => {
   const {
-    draft,
     attachment,
     priority,
     sendState,
-    reset,
     setSendState,
     feeState,
     setAttachment,
+    clearDraft,
   } = useComposerStore();
+
+  const draft = useComposerStore((s) =>
+    recipient ? s.drafts[recipient] || "" : ""
+  );
   const walletStore = useWalletStore();
   const messageStore = useMessagingStore();
 
@@ -143,7 +146,12 @@ export const useMessageComposer = (recipient?: string) => {
       // keep the conversation open with the same recipient
       messageStore.setOpenedRecipient(recipient);
 
-      reset();
+      // clear only this contact's draft and reset other states
+      if (recipient) {
+        clearDraft(recipient);
+      }
+      setAttachment(null);
+      setSendState({ status: "idle" });
     } catch (error) {
       console.error("Error sending message:", error);
       setSendState({ status: "error", error: error as Error });

--- a/src/store/featureflag.store.ts
+++ b/src/store/featureflag.store.ts
@@ -1,14 +1,14 @@
 import { create } from "zustand";
-import { Dices, LucideIcon } from "lucide-react";
+import { PencilRuler, LucideIcon } from "lucide-react";
 
 export enum FeatureFlags {
-  GAME_FRAME = "gameframe",
+  RICH_TEXT = "richtext",
 }
 
 export type FeatureFlagsTable = Record<FeatureFlags, boolean>;
 
 const defaultFeatureFlagsTable: FeatureFlagsTable = {
-  [FeatureFlags.GAME_FRAME]: false,
+  [FeatureFlags.RICH_TEXT]: false,
 };
 
 export interface FeatureDescription {
@@ -20,10 +20,10 @@ export interface FeatureDescription {
 export type FeatureFlips = Record<FeatureFlags, FeatureDescription>;
 
 const featureFlips: FeatureFlips = {
-  [FeatureFlags.GAME_FRAME]: {
+  [FeatureFlags.RICH_TEXT]: {
     label: "Game Frame",
     desc: "NOT IMPLEMENTED - JUST FOR FLAG DEMO.",
-    icon: Dices,
+    icon: PencilRuler,
   },
 };
 

--- a/src/store/message-composer.store.ts
+++ b/src/store/message-composer.store.ts
@@ -1,0 +1,77 @@
+import { create } from "zustand";
+import { PriorityFeeConfig } from "../types/all";
+import { FeeSource } from "kaspa-wasm";
+
+// attachment types
+export interface BaseAttachment {
+  name: string;
+  mime: string;
+  data: string;
+  size: number;
+}
+
+export interface FileAttachment extends BaseAttachment {
+  type: "file";
+}
+
+export interface ImageAttachment extends BaseAttachment {
+  type: "image";
+  width?: number;
+  height?: number;
+}
+
+export type Attachment = FileAttachment | ImageAttachment | null;
+
+interface ComposerState {
+  draft: string;
+  attachment: Attachment | null;
+  priority: PriorityFeeConfig;
+
+  feeState: {
+    status: "idle" | "loading" | "error";
+    error?: Error;
+    value?: number;
+  };
+  sendState: { status: "idle" | "loading" | "error"; error?: Error };
+
+  // actions
+  setDraft: (draft: string) => void;
+  setAttachment: (attachment: Attachment | null) => void;
+  setPriority: (priority: PriorityFeeConfig) => void;
+  setFeeState: (state: {
+    status: "idle" | "loading" | "error";
+    error?: Error;
+    value?: number;
+  }) => void;
+  setSendState: (state: {
+    status: "idle" | "loading" | "error";
+    error?: Error;
+  }) => void;
+  reset: () => void;
+}
+
+export const useComposerStore = create<ComposerState>((set) => ({
+  draft: "",
+  attachment: null,
+  priority: { amount: 0n, source: FeeSource.SenderPays },
+  feeState: { status: "idle" },
+  sendState: { status: "idle" },
+
+  setDraft: (draft) => set({ draft }),
+  setAttachment: (attachment) => set({ attachment }),
+  setPriority: (priority) => set({ priority }),
+  setFeeState: (feeState) => set({ feeState }),
+  setSendState: (sendState) => set({ sendState }),
+  reset: () =>
+    set({
+      draft: "",
+      attachment: null,
+      priority: { amount: 0n, source: FeeSource.SenderPays },
+      feeState: { status: "idle" },
+      sendState: { status: "idle" },
+    }),
+}));
+
+// selector helper
+export const useComposerSlice = <T>(selector: (state: ComposerState) => T) =>
+  useComposerStore(selector);

--- a/src/store/message-composer.store.ts
+++ b/src/store/message-composer.store.ts
@@ -23,7 +23,7 @@ export interface ImageAttachment extends BaseAttachment {
 export type Attachment = FileAttachment | ImageAttachment | null;
 
 interface ComposerState {
-  draft: string;
+  drafts: Record<string, string>;
   attachment: Attachment | null;
   priority: PriorityFeeConfig;
 
@@ -35,7 +35,7 @@ interface ComposerState {
   sendState: { status: "idle" | "loading" | "error"; error?: Error };
 
   // actions
-  setDraft: (draft: string) => void;
+  setDraft: (recipient: string, draft: string) => void;
   setAttachment: (attachment: Attachment | null) => void;
   setPriority: (priority: PriorityFeeConfig) => void;
   setFeeState: (state: {
@@ -47,24 +47,36 @@ interface ComposerState {
     status: "idle" | "loading" | "error";
     error?: Error;
   }) => void;
+  getDraft: (recipient: string) => string;
+  clearDraft: (recipient: string) => void;
   reset: () => void;
 }
 
-export const useComposerStore = create<ComposerState>((set) => ({
-  draft: "",
+export const useComposerStore = create<ComposerState>((set, get) => ({
+  drafts: {},
   attachment: null,
   priority: { amount: 0n, source: FeeSource.SenderPays },
   feeState: { status: "idle" },
   sendState: { status: "idle" },
 
-  setDraft: (draft) => set({ draft }),
+  setDraft: (recipient, draft) =>
+    set((state) => ({
+      drafts: { ...state.drafts, [recipient]: draft },
+    })),
   setAttachment: (attachment) => set({ attachment }),
   setPriority: (priority) => set({ priority }),
   setFeeState: (feeState) => set({ feeState }),
   setSendState: (sendState) => set({ sendState }),
+  getDraft: (recipient) => get().drafts[recipient] || "",
+  clearDraft: (recipient) =>
+    set((state) => {
+      const cleanDrafts = { ...state.drafts };
+      delete cleanDrafts[recipient];
+      return { drafts: cleanDrafts };
+    }),
   reset: () =>
     set({
-      draft: "",
+      drafts: {},
       attachment: null,
       priority: { amount: 0n, source: FeeSource.SenderPays },
       feeState: { status: "idle" },


### PR DESCRIPTION
## what?
this refactors the send message form 
deleting it, adding a store and trying to handle _everything_ just a little bit better.

hopefully paves the way for if and when we get rich text editor like tiptap

it loosely sets a soft standard for following store / hook interactions, discussed in discord [around here](https://discord.com/channels/1359255794675089558/1360035142172676226/1402177141793099786)

>1 hook for 1 store, and for complex case 1 hook for n hooks - n store? creating a "manager hook" on top of the others?

_store use for _pure_ state updates are fine, but if there are side effects, then we go through a hook._

**rebased
originally I had deleted `SendMessageForm` but the indexeddb has some changes to it (that I will need to migrate to the new files). I will do this once we are at parity with staging.**