### PR TITLE
fix(history/message): loading offline message from indexer

### DIFF
--- a/src/service/historical-syncer.ts
+++ b/src/service/historical-syncer.ts
@@ -32,7 +32,10 @@ export class HistoricalSyncer {
     const messages = await getContextualMessagesBySender({
       query: {
         address: from,
-        alias,
+        // encode alias as hex string using text encoder
+        alias: new TextEncoder()
+          .encode(alias)
+          .reduce((acc, byte) => acc + byte.toString(16).padStart(2, "0"), ""),
       },
     });
 


### PR DESCRIPTION
* encode the `alias` as `hex(alias)` before passing it to indexer, as indexer consider alias is the encoded payload part
* upon receiving new offline handhshakes, also load contextual messages on this (new/ yet unknown) handshake alias. previously we were searching for this alias on all unknown handshakes regardless of the sender/conversation. this was a bug
* properly decode the message payload prior decrypting it