### PR TITLE
Handshakev2/mods

### DIFF
--- a/src/components/Layout/ModalHost.tsx
+++ b/src/components/Layout/ModalHost.tsx
@@ -111,43 +111,6 @@ export const ModalHost = () => {
         </Modal>
       )}
 
-      {/* Warning Costly Send Message Modal */}
-      {modals["warn-costy-send-message"] && (
-        <Modal onClose={() => closeModal("warn-costy-send-message")}>
-          <div className="flex flex-col items-center justify-center gap-8">
-            <h2 className="text-lg text-yellow-400">
-              <AlertTriangle className="mr-2 inline size-6 text-yellow-400" />
-              Your Correspondent hasn't answered yet
-            </h2>
-
-            <p className="text-center">
-              Sending this message will carry an{" "}
-              <span className="font-bold">extra cost of 0.2 KAS</span>, that
-              will be sent to your correspondent. Are you sure you want to send
-              it?
-            </p>
-            <div className="flex items-start justify-start rounded-lg border border-[#B6B6B6]/20 bg-gradient-to-br from-[#B6B6B6]/10 to-[#B6B6B6]/5 px-4 py-2">
-              <Info className="mr-2 size-10 text-white" />
-              <p className="">
-                This is occuring because your correspondent hasn't accepted the
-                handshake yet.
-              </p>
-            </div>
-
-            <Button
-              onClick={() => {
-                closeModal("warn-costy-send-message");
-                if (sendMessageCallback) {
-                  sendMessageCallback();
-                }
-              }}
-            >
-              Send anyway
-            </Button>
-          </div>
-        </Modal>
-      )}
-
       {/* New Chat Form Modal (from messaging store) */}
       {messageStore.isCreatingNewChat && (
         <Modal onClose={() => messageStore.setIsCreatingNewChat(false)}>

--- a/src/components/MessageComposer/MessageComposerShell.tsx
+++ b/src/components/MessageComposer/MessageComposerShell.tsx
@@ -122,13 +122,6 @@ export const MessageComposerShell = ({ recipient }: { recipient?: string }) => {
       throw new Error("Conversation does not exist");
     }
 
-    // @TODO: this is useless now?
-    // should we prompt a one-time warn that me not have participant's alias and hence it's possible the participant will not read/reply?
-    // if (exists.conversation.status !== "active") {
-    //   setSendMessageCallback(() => send);
-    //   openModal("warn-costy-send-message");
-    //   return;
-    // }
     await send(exists.conversation.myAlias);
   };
 

--- a/src/hooks/MessageComposer/useMessageComposer.ts
+++ b/src/hooks/MessageComposer/useMessageComposer.ts
@@ -49,9 +49,13 @@ export const useMessageComposer = (feeState: FeeState, recipient?: string) => {
     }
   };
 
-  const send = async (myAlias?: string) => {
+  const send = async (myAlias: string) => {
     if (!recipient) {
       toast.error("Error, please select a contact.");
+      return;
+    }
+    if (!myAlias) {
+      toast.error("Valid Alias needed for sending.");
       return;
     }
     if (!walletStore.unlockedWallet) {
@@ -105,22 +109,13 @@ export const useMessageComposer = (feeState: FeeState, recipient?: string) => {
       }
 
       let txId = "";
-      if (myAlias) {
-        txId = await walletStore.sendMessageWithContext({
-          message: messageToSend,
-          toAddress: new Address(recipient),
-          password: walletStore.unlockedWallet.password,
-          myAlias,
-          priorityFee: priority,
-        });
-      } else {
-        txId = await walletStore.sendMessage({
-          message: messageToSend,
-          toAddress: new Address(recipient),
-          password: walletStore.unlockedWallet.password,
-          priorityFee: priority,
-        });
-      }
+      txId = await walletStore.sendMessageWithContext({
+        message: messageToSend,
+        toAddress: new Address(recipient),
+        password: walletStore.unlockedWallet.password,
+        myAlias,
+        priorityFee: priority,
+      });
 
       const event: KasiaTransaction = {
         transactionId: txId,

--- a/src/service/account-service.ts
+++ b/src/service/account-service.ts
@@ -30,7 +30,7 @@ import {
   TransactionId,
   getTransactionId,
   getTransactionPayload,
-  isIndexerTransaction,
+  isExplorerTransaction,
   isITransaction,
 } from "../types/transactions";
 import { useMessagingStore } from "../store/messaging.store";
@@ -1121,7 +1121,7 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
           }
         }
       } else if (
-        isIndexerTransaction(tx) &&
+        isExplorerTransaction(tx) &&
         tx.inputs &&
         tx.inputs.length > 0
       ) {
@@ -1150,7 +1150,7 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
       // If we still don't have a sender address, try to fetch it from the previous transaction
       if (
         !senderAddress &&
-        isIndexerTransaction(tx) &&
+        isExplorerTransaction(tx) &&
         tx.inputs &&
         tx.inputs.length > 0
       ) {

--- a/src/store/ui.store.ts
+++ b/src/store/ui.store.ts
@@ -15,7 +15,6 @@ export type ModalType =
   | "backup"
   | "delete"
   | "seed"
-  | "warn-costy-send-message"
   | "utxo-compound"
   | "settings"
   | "contact-info-modal"

--- a/src/types/transactions.ts
+++ b/src/types/transactions.ts
@@ -41,7 +41,7 @@ export interface ExplorerOutput {
 // Type guards and helper functions for ITransaction | ExplorerTransaction
 import { ITransaction } from "kaspa-wasm";
 
-export function isIndexerTransaction(
+export function isExplorerTransaction(
   tx: ITransaction | ExplorerTransaction
 ): tx is ExplorerTransaction {
   return "transaction_id" in tx && "block_hash" in tx;
@@ -57,7 +57,7 @@ export function isITransaction(
 export function getTransactionId(
   tx: ITransaction | ExplorerTransaction
 ): string | undefined {
-  return isIndexerTransaction(tx)
+  return isExplorerTransaction(tx)
     ? tx.transaction_id
     : tx.verboseData?.transactionId;
 }
@@ -69,7 +69,7 @@ export function getTransactionPayload(
 }
 
 export function getBlockTime(tx: ITransaction | ExplorerTransaction): number {
-  return isIndexerTransaction(tx)
+  return isExplorerTransaction(tx)
     ? tx.block_time
     : Number(tx.verboseData?.blockTime);
 }

--- a/src/types/transactions.ts
+++ b/src/types/transactions.ts
@@ -41,7 +41,7 @@ export interface ExplorerOutput {
 // Type guards and helper functions for ITransaction | ExplorerTransaction
 import { ITransaction } from "kaspa-wasm";
 
-export function isExplorerTransaction(
+export function isIndexerTransaction(
   tx: ITransaction | ExplorerTransaction
 ): tx is ExplorerTransaction {
   return "transaction_id" in tx && "block_hash" in tx;
@@ -57,7 +57,7 @@ export function isITransaction(
 export function getTransactionId(
   tx: ITransaction | ExplorerTransaction
 ): string | undefined {
-  return isExplorerTransaction(tx)
+  return isIndexerTransaction(tx)
     ? tx.transaction_id
     : tx.verboseData?.transactionId;
 }
@@ -69,7 +69,7 @@ export function getTransactionPayload(
 }
 
 export function getBlockTime(tx: ITransaction | ExplorerTransaction): number {
-  return isExplorerTransaction(tx)
+  return isIndexerTransaction(tx)
     ? tx.block_time
     : Number(tx.verboseData?.blockTime);
 }


### PR DESCRIPTION
# what?
some mods to the handshake pr

remove non-contextual tx submission logic
- we can only ever send contextual messages from the message composer

remove costly warn modal 
- not needed, see above

remove indexer fetching if there is no alias. 
-this prevents a user from seeing messages if they have not accepted the handshake. although its possible to read them, its in best interest to protect people from spam or any wanted messages.

remove payment message if no alias
- this was a sidestep around the above logic, we now do not show the added messages (but we still show the funds landing) if handshake is not accepted.

after handshake accept, we poll indexer for historical messages
- due to the above

+ some misc refactors and renaming