### PR TITLE
fix: fee alt approach

### DIFF
--- a/src/components/MessageDisplay/Bubble/Meta/FeeDisplay.tsx
+++ b/src/components/MessageDisplay/Bubble/Meta/FeeDisplay.tsx
@@ -11,7 +11,7 @@ export const FeeDisplay: FC<FeeDisplayProps> = ({
   isOutgoing,
   className = "message-fee text-right",
 }) => {
-  if (isOutgoing && fee !== undefined) {
+  if (isOutgoing && fee !== undefined && fee > 0) {
     return (
       <div className="w-full">
         <div className={className}>Fee: {fee.toFixed(8)} KAS</div>

--- a/src/components/MessageDisplay/Bubble/Utils/BubbleClassGenerator.tsx
+++ b/src/components/MessageDisplay/Bubble/Utils/BubbleClassGenerator.tsx
@@ -29,7 +29,7 @@ export const generateBubbleClasses = (
   })();
 
   return clsx(
-    "relative z-0 mb-1 max-w-[70%] cursor-pointer px-4 py-1 text-left break-words hyphens-auto",
+    "relative z-0 max-w-[70%] cursor-pointer px-4 py-1 text-left break-words hyphens-auto",
     isOutgoing
       ? "border border-[var(--button-primary)] bg-[var(--button-primary)]/20"
       : "bg-[var(--secondary-bg)]",

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -9,8 +9,10 @@ export const ALIAS_LENGTH = 6; // 6 bytes = 12 hex characters
 // Placeholder alias for fee estimation and testing (12 hex chars = 6 bytes)
 export const PLACEHOLDER_ALIAS = "000000000000";
 
-// Maximum priority fee (5 KAS) - Originally 10 but lowering for intial release
-export const MAX_PRIORITY_FEE = BigInt(5 * 100_000_000);
+// Maximum priority fee (2 KAS)
+export const MAX_PRIORITY_FEE = BigInt(2 * 100_000_000);
+// Maximum fee pre sign and submit (max priority plus 10% buffer)
+export const MAX_TX_FEE = (MAX_PRIORITY_FEE * BigInt(11)) / BigInt(10);
 
 // Standard transaction mass in grams (typical Kaspa transaction)
 export const STANDARD_TRANSACTION_MASS = 2036;

--- a/src/hooks/MessageComposer/useMessageComposer.ts
+++ b/src/hooks/MessageComposer/useMessageComposer.ts
@@ -73,16 +73,6 @@ export const useMessageComposer = (feeState: FeeState, recipient?: string) => {
       return;
     }
 
-    // require valid fee state before sending
-    if (
-      !feeState ||
-      feeState.status !== "idle" ||
-      typeof feeState.value !== "number"
-    ) {
-      toast.error("Please wait for fee calculation to complete.");
-      return;
-    }
-
     if (sendState.status === "loading") {
       return;
     }
@@ -128,7 +118,7 @@ export const useMessageComposer = (feeState: FeeState, recipient?: string) => {
           ? JSON.stringify(fileDataForStorage)
           : draft,
         amount: 20000000,
-        fee: feeState.value,
+        fee: feeState.value || 0,
         payload: "",
       };
 

--- a/src/service/account-service.ts
+++ b/src/service/account-service.ts
@@ -40,6 +40,7 @@ import { PROTOCOL, VERSION } from "../config/protocol";
 import { PLACEHOLDER_ALIAS } from "../config/constants";
 import { parseKaspaMessagePayload } from "../utils/message-payload";
 import { WalletStorageService } from "./wallet-storage-service";
+import { MAX_TX_FEE } from "../config/constants";
 
 // Message related types
 type DecodedMessage = {
@@ -400,6 +401,12 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
 
       if ((await generator.next()) !== null) {
         throw new Error("Unexpected multiple transaction generation");
+      }
+
+      if (pendingTransaction.feeAmount > MAX_TX_FEE) {
+        throw new Error(
+          `Fee cannot exceed ${Number(MAX_TX_FEE) / 100_000_000} KAS`
+        );
       }
 
       // Log the addresses that need signing

--- a/src/service/conversation-manager-service.ts
+++ b/src/service/conversation-manager-service.ts
@@ -638,7 +638,9 @@ export class ConversationManagerService {
     Array.from(this.conversationWithContactByConversationId.values())
       .filter(
         (conversationAndContact) =>
-          conversationAndContact.conversation.status === "active"
+          conversationAndContact.conversation.status === "active" ||
+          (conversationAndContact.conversation.status === "pending" &&
+            conversationAndContact.conversation.initiatedByMe)
       )
       .forEach((conversationAndContact) => {
         // Monitor our own alias


### PR DESCRIPTION
## what
- fix fee estimation on pre-handshake messages and block a handshake receiver from sending messages.

- stop fee estimation not being resolved from blocking (we do not use this to send tx)
^ - alter message bubble for this behavior 

- add a hard limit _post generator pre submission_ that gets the accurate fee. Limiting this to 2 kas + 10%. _This is just an initial hard limit which can be altered or put into settings later on_

- style - tighten up bubble spacing (previously was this tight but regressed during refactor pr recently)