### PR TITLE
Fix-Do/A lot

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,7 +11,7 @@ env:
   SUFFIX: ${{ github.ref_name == 'master' && 'production' || 'staging' }}
 
 jobs:
-  lint-and-type-check:
+  lint-type-check-and-test:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -35,3 +35,6 @@ jobs:
 
       - name: Run TypeScript type check
         run: npm run type-check
+
+      - name: Run Tests
+        run: npm run test

--- a/src/components/Common/modal.tsx
+++ b/src/components/Common/modal.tsx
@@ -45,7 +45,7 @@ export const Modal: FC<{
     >
       <div
         className={clsx(
-          "border-primary-border bg-secondary-bg relative mx-4 w-full max-w-2xl rounded-2xl border p-6 transition-all duration-200",
+          "border-primary-border bg-secondary-bg relative mx-4 w-full max-w-2xl rounded-2xl border p-3 transition-all duration-200 sm:p-6",
           {
             "translate-y-0 opacity-100": mounted,
             "-translate-y-5 opacity-0": !mounted,
@@ -55,7 +55,7 @@ export const Modal: FC<{
       >
         <button
           onClick={handleClose}
-          className="hover:text-kas-secondary absolute top-2 right-2 z-60 cursor-pointer p-2 hover:scale-110"
+          className="hover:text-kas-secondary absolute top-0.5 right-0.5 z-60 cursor-pointer p-2 hover:scale-110 sm:top-2 sm:right-2"
         >
           <X className="bg-primary-bg border-primary-border h-7 w-7 rounded-3xl border p-1" />
         </button>

--- a/src/components/Layout/DesktopMenu.tsx
+++ b/src/components/Layout/DesktopMenu.tsx
@@ -120,18 +120,6 @@ export const DesktopMenu: FC<DesktopMenuProps> = ({
                         <span className="text-sm">Withdraw Funds</span>
                       </li>
 
-                      {/* Compound */}
-                      <li
-                        onClick={() => {
-                          openModal("utxo-compound");
-                          setWalletMenuOpen(false);
-                        }}
-                        className="hover:bg-secondary-bg flex cursor-pointer items-center gap-2 px-4 py-3"
-                      >
-                        <Wallet className="h-5 w-5" />
-                        <span className="text-sm">Compound UTXOs</span>
-                      </li>
-
                       {/* Seed */}
                       <li
                         onClick={() => {
@@ -276,18 +264,6 @@ export const DesktopMenu: FC<DesktopMenuProps> = ({
                       >
                         <Wallet className="h-5 w-5" />
                         <span className="text-sm">Withdraw Funds</span>
-                      </li>
-
-                      {/* Compound */}
-                      <li
-                        onClick={() => {
-                          openModal("utxo-compound");
-                          setWalletMenuOpen(false);
-                        }}
-                        className="hover:bg-secondary-bg flex cursor-pointer items-center gap-2 px-4 py-3"
-                      >
-                        <Wallet className="h-5 w-5" />
-                        <span className="text-sm">Compound UTXOs</span>
                       </li>
 
                       {/* Seed */}

--- a/src/components/Layout/ModalHost.tsx
+++ b/src/components/Layout/ModalHost.tsx
@@ -3,7 +3,6 @@ import { useWalletStore } from "../../store/wallet.store";
 import { useMessagingStore } from "../../store/messaging.store";
 import { Modal } from "../Common/modal";
 import { MessageBackup } from "../Modals/MessageBackup";
-import { UtxoCompound } from "../Modals/UtxoCompound";
 import { WalletAddressSection } from "../Modals/WalletAddressSection";
 import { WalletInfo } from "../Modals/WalletInfo";
 import { WalletSeedRetreiveDisplay } from "../Modals/WalletSeedRetreiveDisplay";
@@ -11,8 +10,7 @@ import { WalletWithdrawal } from "../Modals/WalletWithdrawal";
 import { LockedSettingsModal } from "../Modals/LockedSettingsModal";
 import { ContactInfoModal } from "../Modals/ContactInfoModal";
 import { NewChatForm } from "../NewChatForm";
-import { LoaderCircle, AlertTriangle, Info } from "lucide-react";
-import { Button } from "../Common/Button";
+import { LoaderCircle } from "lucide-react";
 import { ImagePresenter } from "../Modals/ImagePresenter";
 
 // This component subscribes to modal state and renders the appropriate modal
@@ -69,13 +67,6 @@ export const ModalHost = () => {
       {modals.seed && (
         <Modal onClose={() => closeModal("seed")}>
           <WalletSeedRetreiveDisplay />
-        </Modal>
-      )}
-
-      {/* UTXO Compound Modal */}
-      {modals["utxo-compound"] && (
-        <Modal onClose={() => closeModal("utxo-compound")}>
-          <UtxoCompound />
         </Modal>
       )}
 

--- a/src/components/Layout/SlideOutMenu.tsx
+++ b/src/components/Layout/SlideOutMenu.tsx
@@ -170,19 +170,6 @@ export const SlideOutMenu: FC<SlideOutMenuProps> = ({
 
                     <button
                       onClick={() => {
-                        openModal("utxo-compound");
-                        setActionsOpen(false);
-                      }}
-                      className="flex w-full cursor-pointer items-center gap-2 rounded-lg px-3 py-2 transition-colors hover:bg-gray-700"
-                    >
-                      <CreditCard className="h-5 w-5 text-[var(--text-primary)]" />
-                      <span className="text-sm text-[var(--text-primary)]">
-                        Compound UTXOs
-                      </span>
-                    </button>
-
-                    <button
-                      onClick={() => {
                         openModal("seed");
                         setActionsOpen(false);
                       }}

--- a/src/components/MessageComposer/FeeDisplay.tsx
+++ b/src/components/MessageComposer/FeeDisplay.tsx
@@ -4,6 +4,7 @@ import { PriorityFeeSelector } from "../PriorityFeeSelector";
 import { PriorityFeeConfig } from "../../types/all";
 import { Attachment } from "../../store/message-composer.store";
 import { FeeState } from "../../types/all";
+import { useWalletStore } from "../../store/wallet.store";
 
 // fee levels for color coding
 // need to extract this and make it setable from the settings
@@ -37,10 +38,15 @@ export const FeeDisplay = ({
   priority,
   onPriorityChange,
 }: FeeDisplayProps) => {
+  const balance = useWalletStore((state) => state.balance);
+
   // only show fee display when we have a recipient and either draft or attachment
   if (!recipient || (!draft && !attachment)) {
     return null;
   }
+
+  // check if there are funds available
+  const hasFunds = balance && balance.mature > 0n;
 
   return (
     <div className="absolute -top-7.5 right-4 flex items-center gap-2">
@@ -50,13 +56,17 @@ export const FeeDisplay = ({
           feeState.value && getFeeClasses(feeState.value)
         )}
       >
-        {feeState.status === "loading"
-          ? feeState.value != null
-            ? `Updating fee… ${formatKasAmount(feeState.value)} KAS`
-            : "Estimating fee…"
-          : feeState.value != null
-            ? `Estimated fee: ${formatKasAmount(feeState.value)} KAS`
-            : "Calculating fee…"}
+        {!hasFunds
+          ? "No funds available"
+          : feeState.status === "loading"
+            ? feeState.value != null
+              ? `Updating fee… ${formatKasAmount(feeState.value)} KAS`
+              : "Estimating fee…"
+            : feeState.value != null
+              ? `Estimated fee: ${formatKasAmount(feeState.value)} KAS`
+              : feeState.status === "error"
+                ? "Fee estimation failed"
+                : "Calculating fee…"}
       </div>
 
       <PriorityFeeSelector

--- a/src/components/MessageComposer/MessageComposerShell.tsx
+++ b/src/components/MessageComposer/MessageComposerShell.tsx
@@ -34,7 +34,12 @@ export const MessageComposerShell = ({ recipient }: { recipient?: string }) => {
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const cameraInputRef = useRef<HTMLInputElement | null>(null);
 
-  const feeState = useFeeEstimate(true, recipient, draft, attachment);
+  const feeState = useFeeEstimate({
+    toSelf: true,
+    recipient,
+    draft,
+    attachment,
+  });
   const { send, attach } = useMessageComposer(feeState, recipient);
   const setPriority = useComposerStore((s) => s.setPriority);
   const setSendState = useComposerStore((s) => s.setSendState);

--- a/src/components/MessageComposer/MessageComposerShell.tsx
+++ b/src/components/MessageComposer/MessageComposerShell.tsx
@@ -81,7 +81,6 @@ export const MessageComposerShell = ({ recipient }: { recipient?: string }) => {
 
   // check message length and trim if over limit
   useEffect(() => {
-    console.log(draft.length);
     if (draft.length > MAX_CHAT_INPUT_CHAR) {
       toast.removeAll();
       toast.error(

--- a/src/components/MessageComposer/MessageComposerShell.tsx
+++ b/src/components/MessageComposer/MessageComposerShell.tsx
@@ -34,7 +34,7 @@ export const MessageComposerShell = ({ recipient }: { recipient?: string }) => {
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const cameraInputRef = useRef<HTMLInputElement | null>(null);
 
-  const feeState = useFeeEstimate(recipient, draft, attachment);
+  const feeState = useFeeEstimate(true, recipient, draft, attachment);
   const { send, attach } = useMessageComposer(feeState, recipient);
   const setPriority = useComposerStore((s) => s.setPriority);
   const setSendState = useComposerStore((s) => s.setSendState);

--- a/src/components/Modals/UtxoCompound.tsx
+++ b/src/components/Modals/UtxoCompound.tsx
@@ -104,10 +104,13 @@ export const UtxoCompound: FC<UtxoCompoundProps> = ({
   return (
     <div className="mt-1">
       <div className="mb-2">
-        <h3 className="mb-1 text-base font-semibold">Compound UTXOs</h3>
-        <p className="text-sm text-[var(--text-secondary)]">
+        <h3 className="mb-1 text-center text-base font-semibold sm:text-left">
+          Compound UTXOs
+        </h3>
+        <p className="text-center text-sm text-[var(--text-secondary)] sm:text-left">
           Combine multiple UTXOs into fewer, larger ones to optimize wallet
-          performance
+          performance. This creates a tx and sends all funds automatically to
+          yourself. Network fees will apply.
         </p>
       </div>
 
@@ -116,7 +119,7 @@ export const UtxoCompound: FC<UtxoCompoundProps> = ({
         <div className="my-2 rounded-lg border border-[var(--accent-yellow)] bg-[var(--secondary-bg)] p-1 sm:my-3">
           <div className="flex flex-col items-center gap-2 text-center sm:flex-row sm:text-left">
             <AlertTriangle className="m-0 size-6 text-[var(--accent-yellow)] sm:m-1" />
-            <div className="text-xs">
+            <div className="text-center text-xs sm:text-left">
               <p className="font-medium text-[var(--accent-yellow)]">
                 High UTXO Count Detected
               </p>

--- a/src/components/Modals/UtxoCompound.tsx
+++ b/src/components/Modals/UtxoCompound.tsx
@@ -1,5 +1,4 @@
 import { RefreshCw, AlertTriangle, XCircle } from "lucide-react";
-import { clsx } from "clsx";
 import { FC, useCallback, useEffect, useState } from "react";
 import { useWalletStore } from "../../store/wallet.store";
 import { Button } from "../Common/Button";

--- a/src/components/Modals/UtxoCompound.tsx
+++ b/src/components/Modals/UtxoCompound.tsx
@@ -19,6 +19,7 @@ type FrozenBalance = {
 
 // Constants
 const HIGH_UTXO_THRESHOLD = 100; // Threshold for showing high UTXO warning
+const UTXO_MIN_COUNT = 2;
 
 export const UtxoCompound: FC = () => {
   const [isCompounding, setIsCompounding] = useState(false);
@@ -36,6 +37,9 @@ export const UtxoCompound: FC = () => {
   const walletStore = useWalletStore();
   const { accountService, unlockedWallet, balance, address, selectedNetwork } =
     walletStore;
+
+  const compoundNotNeeded =
+    balance?.matureUtxoCount && balance?.matureUtxoCount < UTXO_MIN_COUNT;
 
   // Monitor balance changes to detect when compound is complete
   useEffect(() => {
@@ -69,14 +73,15 @@ export const UtxoCompound: FC = () => {
     return "Transaction failed. Please check your connection and try again.";
   }, []);
 
-  const handleCompoundUtxos = useCallback(async () => {
-    if (!accountService || !unlockedWallet || !address) {
-      setError("Wallet not properly initialized");
+  const handleCompoundUtxos = async () => {
+    if (
+      !accountService ||
+      !unlockedWallet ||
+      !address ||
+      !balance?.matureUtxoCount ||
+      compoundNotNeeded
+    ) {
       return;
-    }
-
-    if (!balance?.matureUtxoCount || balance.matureUtxoCount < 2) {
-      return; // Silently do nothing if not enough UTXOs
     }
 
     setIsCompounding(true);
@@ -106,14 +111,7 @@ export const UtxoCompound: FC = () => {
     } finally {
       setIsCompounding(false);
     }
-  }, [
-    accountService,
-    unlockedWallet,
-    balance,
-    address,
-    resetAllStates,
-    getUserFriendlyErrorMessage,
-  ]);
+  };
 
   if (!balance) {
     return (
@@ -226,12 +224,12 @@ export const UtxoCompound: FC = () => {
 
       {/* Results */}
       {error && (
-        <div className="bg-opacity-10 border-opacity-30 rounded-lg border border-red-500 bg-red-500 p-3">
-          <div className="flex items-start gap-2">
-            <XCircle className="mt-0.5 h-5 w-5 flex-shrink-0 text-red-400" />
+        <div className="bg-opacity-10 border-opacity-30 rounded-lg border border-[var(--accent-red)] bg-[var(--accent-red)] p-3">
+          <div className="flex items-start gap-2 text-white">
+            <XCircle className="mt-0.5 h-5 w-5 flex-shrink-0" />
             <div className="text-base">
-              <p className="font-medium text-red-400">Error</p>
-              <p className="text-[var(--text-secondary)]-300 mt-1">{error}</p>
+              <p className="font-medium">Error</p>
+              <p className="mt-1">{error}</p>
             </div>
           </div>
         </div>
@@ -252,7 +250,7 @@ export const UtxoCompound: FC = () => {
                   Transaction ID:
                 </span>{" "}
                 <a
-                  href={getExplorerUrl(compoundResult.txId)}
+                  href={getExplorerUrl(compoundResult.txId, selectedNetwork)}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="break-all text-blue-300 underline hover:text-blue-200"

--- a/src/components/Modals/UtxoCompound.tsx
+++ b/src/components/Modals/UtxoCompound.tsx
@@ -1,16 +1,8 @@
 import { RefreshCw, AlertTriangle, XCircle } from "lucide-react";
 import { clsx } from "clsx";
-import { Address } from "kaspa-wasm";
 import { FC, useCallback, useEffect, useState } from "react";
 import { useWalletStore } from "../../store/wallet.store";
 import { Button } from "../Common/Button";
-import { getExplorerUrl } from "../../utils/explorer-url";
-
-// Type definitions
-type CompoundResult = {
-  txId: string;
-  utxoCount: number;
-};
 
 type FrozenBalance = {
   matureUtxoCount: number;
@@ -18,45 +10,29 @@ type FrozenBalance = {
 };
 
 // Constants
-const HIGH_UTXO_THRESHOLD = 100; // Threshold for showing high UTXO warning
+const HIGH_UTXO_THRESHOLD = 20; // Threshold for showing high UTXO warning
 const UTXO_MIN_COUNT = 2;
 
 export const UtxoCompound: FC = () => {
   const [isCompounding, setIsCompounding] = useState(false);
-  const [compoundResult, setCompoundResult] = useState<CompoundResult | null>(
-    null
-  );
   const [error, setError] = useState<string | null>(null);
-  const [pendingResult, setPendingResult] = useState<CompoundResult | null>(
-    null
-  );
   const [frozenBalance, setFrozenBalance] = useState<FrozenBalance | null>(
     null
   );
 
   const walletStore = useWalletStore();
-  const { accountService, unlockedWallet, balance, address, selectedNetwork } =
-    walletStore;
+  const { accountService, unlockedWallet, balance, address } = walletStore;
 
   const compoundNotNeeded =
     balance?.matureUtxoCount && balance?.matureUtxoCount < UTXO_MIN_COUNT;
 
   // Monitor balance changes to detect when compound is complete
   useEffect(() => {
-    if (pendingResult && balance?.matureUtxoCount === 1 && !isCompounding) {
+    if (balance?.matureUtxoCount === 1 && !isCompounding) {
       // Compound is complete: we have exactly 1 UTXO and not processing anymore
-      setCompoundResult(pendingResult);
-      setPendingResult(null);
       setFrozenBalance(null); // Clear frozen balance to show final result
     }
-  }, [balance?.matureUtxoCount, isCompounding, pendingResult]);
-
-  const resetAllStates = useCallback(() => {
-    setError(null);
-    setCompoundResult(null);
-    setFrozenBalance(null);
-    setPendingResult(null);
-  }, []);
+  }, [balance?.matureUtxoCount, isCompounding]);
 
   const getUserFriendlyErrorMessage = useCallback((err: unknown): string => {
     if (!(err instanceof Error)) return "Transaction failed. Please try again.";
@@ -85,7 +61,8 @@ export const UtxoCompound: FC = () => {
     }
 
     setIsCompounding(true);
-    resetAllStates();
+    setError(null);
+    setFrozenBalance(null);
 
     // Freeze the balance display during processing
     setFrozenBalance({
@@ -107,65 +84,29 @@ export const UtxoCompound: FC = () => {
     }
   };
 
-  if (!balance) {
-    return (
-      <div className="p-4 text-center">
-        <p className="text-[var(--text-secondary)]">
-          Loading wallet information...
-        </p>
-      </div>
-    );
-  }
-
   // Use frozen balance during processing, otherwise use current balance
   const displayBalance = frozenBalance || balance;
 
-  const shouldShowCompound = Boolean(
-    balance?.matureUtxoCount && balance.matureUtxoCount >= 2
-  );
   const isHighUtxoCount = Boolean(
     displayBalance?.matureUtxoCount &&
       displayBalance.matureUtxoCount > HIGH_UTXO_THRESHOLD
   );
 
+  if (compoundNotNeeded) return;
+
   return (
-    <div className="space-y-4 p-4">
-      <div className="text-center">
-        <h3 className="mb-2 text-lg font-semibold">Compound UTXOs</h3>
-        <p className="mb-4 text-base text-[var(--text-secondary)]">
+    <div className="mt-1">
+      <div className="mb-1">
+        <h3 className="mb-2 text-base font-semibold">Compound UTXOs</h3>
+        <p className="text-xs text-[var(--text-secondary)]">
           Combine multiple UTXOs into fewer, larger ones to optimize wallet
           performance
         </p>
       </div>
 
-      {/* UTXO Information */}
-      <div className="border-primary-border bg-primary-bg rounded-lg border p-4">
-        <div className="grid grid-cols-2 gap-4 text-base">
-          <div>
-            <span className="text-[var(--text-secondary)]">Mature UTXOs:</span>
-            <div
-              className={clsx("font-semibold", {
-                "text-orange-400": isHighUtxoCount,
-              })}
-            >
-              {displayBalance?.matureUtxoCount ?? "-"}
-              {isHighUtxoCount && (
-                <span className="ml-1 text-xs text-orange-400">(High)</span>
-              )}
-            </div>
-          </div>
-          <div>
-            <span className="text-[var(--text-secondary)]">Total Balance:</span>
-            <div className="font-semibold">
-              {displayBalance?.matureDisplay} KAS
-            </div>
-          </div>
-        </div>
-      </div>
-
       {/* Performance Warning */}
       {isHighUtxoCount && (
-        <div className="bg-opacity-10 border-opacity-30 rounded-lg border border-orange-500 bg-orange-500 p-3">
+        <div className="bg-opacity-10 border-opacity-30 rounded-lg border border-orange-500 bg-orange-500">
           <div className="flex items-start gap-2">
             <AlertTriangle className="mt-0.5 h-5 w-5 flex-shrink-0 text-orange-400" />
             <div className="text-base">
@@ -181,32 +122,23 @@ export const UtxoCompound: FC = () => {
         </div>
       )}
 
-      {/* Information Box */}
-      <div className="border-primary-border bg-primary-bg rounded-lg border p-3">
-        <div className="flex w-full items-center justify-center gap-2">
-          <p className="text-base font-semibold">How it works:</p>
-        </div>
-        <ul className="space-y-1 text-center text-sm text-[var(--text-secondary)]">
-          <li>Combines multiple small UTXOs into fewer larger ones</li>
-        </ul>
-      </div>
-
       {/* Action Buttons */}
-      <div className="space-y-3">
+      <div className="my-1 space-y-1">
         {/* Show compound button only if we have enough UTXOs and not processing/completed */}
-        {shouldShowCompound &&
-          !isCompounding &&
-          !compoundResult &&
-          !pendingResult && (
-            <Button onClick={handleCompoundUtxos} variant="primary">
-              Compound {balance?.matureUtxoCount ?? 0} UTXOs
-            </Button>
-          )}
+        {!compoundNotNeeded && !isCompounding && (
+          <Button
+            onClick={handleCompoundUtxos}
+            variant="primary"
+            className="!p-1"
+          >
+            Compound {balance?.matureUtxoCount} UTXOs
+          </Button>
+        )}
 
         {/* Processing State */}
-        {(isCompounding || pendingResult) && !compoundResult && (
-          <div className="border-primary-border bg-primary-bg rounded-lg border p-4 text-center">
-            <div className="text-kas-secondary flex items-center justify-center gap-2">
+        {isCompounding && (
+          <div className="border-primary-border bg-primary-bg rounded-lg border p-1">
+            <div className="text-kas-secondary flex items-center gap-1">
               <RefreshCw className="h-5 w-5 animate-spin" />
               <span className="font-medium">
                 Processing compound transaction
@@ -224,34 +156,6 @@ export const UtxoCompound: FC = () => {
             <div className="text-base">
               <p className="font-medium">Error</p>
               <p className="mt-1">{error}</p>
-            </div>
-          </div>
-        </div>
-      )}
-
-      {compoundResult && (
-        <div className="bg-opacity-20 border-opacity-50 rounded-lg border border-green-500 bg-green-600 p-3">
-          <div className="flex items-start gap-2">
-            <div className="text-base text-white">
-              <p className="font-semibold">Success</p>
-              <p className="mt-1">
-                Compound transaction successful! Your {compoundResult.utxoCount}{" "}
-                UTXOs have been consolidated into 1 larger UTXO. The transaction
-                is now confirming on the network.
-              </p>
-              <p className="text-[var(--text-secondary)]-200 mt-2">
-                <span className="text-[var(--text-secondary)]-300">
-                  Transaction ID:
-                </span>{" "}
-                <a
-                  href={getExplorerUrl(compoundResult.txId, selectedNetwork)}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="break-all text-blue-300 underline hover:text-blue-200"
-                >
-                  {compoundResult.txId.substring(0, 8)}...
-                </a>
-              </p>
             </div>
           </div>
         </div>

--- a/src/components/Modals/UtxoCompound.tsx
+++ b/src/components/Modals/UtxoCompound.tsx
@@ -8,11 +8,17 @@ type FrozenBalance = {
   matureDisplay: string;
 };
 
+type UtxoCompoundProps = {
+  onFrozenBalanceChange?: (frozenBalance: FrozenBalance | null) => void;
+};
+
 // Constants
-const HIGH_UTXO_THRESHOLD = 20; // Threshold for showing high UTXO warning
+const HIGH_UTXO_THRESHOLD = 1; // Threshold for showing high UTXO warning
 const UTXO_MIN_COUNT = 2;
 
-export const UtxoCompound: FC = () => {
+export const UtxoCompound: FC<UtxoCompoundProps> = ({
+  onFrozenBalanceChange,
+}) => {
   const [isCompounding, setIsCompounding] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [frozenBalance, setFrozenBalance] = useState<FrozenBalance | null>(
@@ -24,6 +30,11 @@ export const UtxoCompound: FC = () => {
 
   const compoundNotNeeded =
     balance?.matureUtxoCount && balance?.matureUtxoCount < UTXO_MIN_COUNT;
+
+  // notify parent whenever frozen balance changes
+  useEffect(() => {
+    onFrozenBalanceChange?.(frozenBalance);
+  }, [frozenBalance, onFrozenBalanceChange]);
 
   // Monitor balance changes to detect when compound is complete
   useEffect(() => {
@@ -83,21 +94,17 @@ export const UtxoCompound: FC = () => {
     }
   };
 
-  // Use frozen balance during processing, otherwise use current balance
-  const displayBalance = frozenBalance || balance;
-
   const isHighUtxoCount = Boolean(
-    displayBalance?.matureUtxoCount &&
-      displayBalance.matureUtxoCount > HIGH_UTXO_THRESHOLD
+    balance?.matureUtxoCount && balance.matureUtxoCount > HIGH_UTXO_THRESHOLD
   );
 
   if (compoundNotNeeded) return;
 
   return (
     <div className="mt-1">
-      <div className="mb-1">
-        <h3 className="mb-2 text-base font-semibold">Compound UTXOs</h3>
-        <p className="text-xs text-[var(--text-secondary)]">
+      <div className="mb-2">
+        <h3 className="mb-1 text-base font-semibold">Compound UTXOs</h3>
+        <p className="text-sm text-[var(--text-secondary)]">
           Combine multiple UTXOs into fewer, larger ones to optimize wallet
           performance
         </p>
@@ -105,16 +112,16 @@ export const UtxoCompound: FC = () => {
 
       {/* Performance Warning */}
       {isHighUtxoCount && (
-        <div className="bg-opacity-10 border-opacity-30 rounded-lg border border-orange-500 bg-orange-500">
-          <div className="flex items-start gap-2">
-            <AlertTriangle className="mt-0.5 h-5 w-5 flex-shrink-0 text-orange-400" />
-            <div className="text-base">
-              <p className="font-medium text-orange-400">
+        <div className="my-2 rounded-lg border border-[var(--accent-yellow)] bg-[var(--secondary-bg)] p-1 sm:my-3">
+          <div className="flex flex-col items-center gap-2 text-center sm:flex-row sm:text-left">
+            <AlertTriangle className="m-0 size-6 text-[var(--accent-yellow)] sm:m-1" />
+            <div className="text-xs">
+              <p className="font-medium text-[var(--accent-yellow)]">
                 High UTXO Count Detected
               </p>
-              <p className="mt-1 text-[var(--text-secondary)]">
+              <p className="mt-1 text-[var(--accent-yellow)]">
                 Having many UTXOs can slow down transactions and increase memory
-                usage. Compounding is recommended for optimal performance.
+                usage. Compounding is recommended for optimal performance
               </p>
             </div>
           </div>
@@ -128,7 +135,7 @@ export const UtxoCompound: FC = () => {
           <Button
             onClick={handleCompoundUtxos}
             variant="primary"
-            className="!p-1"
+            className="!p-1.5"
           >
             Compound {balance?.matureUtxoCount} UTXOs
           </Button>
@@ -136,9 +143,9 @@ export const UtxoCompound: FC = () => {
 
         {/* Processing State */}
         {isCompounding && (
-          <div className="border-primary-border bg-primary-bg rounded-lg border p-1">
-            <div className="text-kas-secondary flex items-center gap-1">
-              <RefreshCw className="h-5 w-5 animate-spin" />
+          <div className="border-primary-border bg-primary-bg rounded-lg border p-2">
+            <div className="text-kas-primary flex items-center gap-1">
+              <RefreshCw className="mx-2 size-6 animate-spin" />
               <span className="font-medium">
                 Processing compound transaction
               </span>

--- a/src/components/Modals/UtxoCompound.tsx
+++ b/src/components/Modals/UtxoCompound.tsx
@@ -2,6 +2,7 @@ import { RefreshCw, AlertTriangle, XCircle } from "lucide-react";
 import { FC, useCallback, useEffect, useState } from "react";
 import { useWalletStore } from "../../store/wallet.store";
 import { Button } from "../Common/Button";
+import { toast } from "../../utils/toast-helper";
 
 type FrozenBalance = {
   matureUtxoCount: number;
@@ -83,15 +84,14 @@ export const UtxoCompound: FC<UtxoCompoundProps> = ({
 
     try {
       const txId = await accountService.createCompoundTransaction();
-
       console.log(`UTXO Compounding succeed, txid: ${txId}`);
-      setFrozenBalance(null); // Clear frozen balance on complete
     } catch (err) {
       console.error("UTXO compounding failed:", err);
       setError(getUserFriendlyErrorMessage(err));
       setFrozenBalance(null); // Clear frozen balance on error
     } finally {
       setIsCompounding(false);
+      toast.success("Success: Funds Compounded");
     }
   };
 

--- a/src/components/Modals/UtxoCompound.tsx
+++ b/src/components/Modals/UtxoCompound.tsx
@@ -94,13 +94,7 @@ export const UtxoCompound: FC = () => {
     });
 
     try {
-      const txId = await accountService.createWithdrawTransaction(
-        {
-          address: new Address(address.toString()), // Send to self
-          amount: balance.mature, // Send entire balance
-        },
-        unlockedWallet.password
-      );
+      const txId = await accountService.createCompoundTransaction();
 
       console.log(`UTXO Compounding succeed, txid: ${txId}`);
       setFrozenBalance(null); // Clear frozen balance on complete

--- a/src/components/Modals/UtxoCompound.tsx
+++ b/src/components/Modals/UtxoCompound.tsx
@@ -13,7 +13,7 @@ type UtxoCompoundProps = {
 };
 
 // Constants
-const HIGH_UTXO_THRESHOLD = 1; // Threshold for showing high UTXO warning
+const HIGH_UTXO_THRESHOLD = 40; // Threshold for showing high UTXO warning
 const UTXO_MIN_COUNT = 2;
 
 export const UtxoCompound: FC<UtxoCompoundProps> = ({
@@ -29,7 +29,8 @@ export const UtxoCompound: FC<UtxoCompoundProps> = ({
   const { accountService, unlockedWallet, balance, address } = walletStore;
 
   const compoundNotNeeded =
-    balance?.matureUtxoCount && balance?.matureUtxoCount < UTXO_MIN_COUNT;
+    !balance?.matureUtxoCount ||
+    (balance?.matureUtxoCount && balance?.matureUtxoCount < UTXO_MIN_COUNT);
 
   // notify parent whenever frozen balance changes
   useEffect(() => {

--- a/src/components/Modals/WalletInfo.tsx
+++ b/src/components/Modals/WalletInfo.tsx
@@ -63,30 +63,38 @@ export const WalletInfo = () => {
         </ul>
       </div>
 
-      <div className="border-primary-border bg-primary-bg mb-4 rounded-2xl border p-4">
-        <h4 className="mb-2 font-bold">UTXO Information</h4>
-        <ul className="my-0 flex list-none flex-col gap-1 p-0 text-sm">
-          <li>
-            <strong>Mature UTXOs:</strong>{" "}
-            <span className="rounded-xl bg-[var(--kas-primary)] px-2 font-bold text-[var(--text-primary)]">
-              {currentBalance?.matureUtxoCount ?? "-"}
-            </span>
-          </li>
-          <li>
-            <strong>Pending UTXOs:</strong>{" "}
-            <span className="rounded-xl bg-[var(--kas-primary)] px-2 font-bold text-[var(--text-primary)]">
-              {currentBalance?.pendingUtxoCount ?? "-"}
-            </span>
-          </li>
-          <li>
-            <strong>Status:</strong>{" "}
-            <span className="status">
-              {!currentBalance?.matureUtxoCount ? "Initializing..." : "Ready"}
-            </span>
-          </li>
-        </ul>
-        <UtxoCompound onFrozenBalanceChange={setFrozenBalance} />
-      </div>
+      {((currentBalance?.matureUtxoCount ?? 0) > 0 ||
+        (currentBalance?.pendingUtxoCount ?? 0) > 0) && (
+        <div className="border-primary-border bg-primary-bg mb-4 rounded-2xl border p-4">
+          <h4 className="mb-2 font-bold">UTXO Information</h4>
+          <ul className="my-0 flex list-none flex-col gap-1 p-0 text-sm">
+            <li>
+              <strong>Mature UTXOs:</strong>{" "}
+              <span className="rounded-xl bg-[var(--kas-primary)] px-2 font-bold text-[var(--text-primary)]">
+                {currentBalance?.matureUtxoCount ?? "-"}
+              </span>
+            </li>
+            <li>
+              <strong>Pending UTXOs:</strong>{" "}
+              <span className="rounded-xl bg-[var(--kas-primary)] px-2 font-bold text-[var(--text-primary)]">
+                {currentBalance?.pendingUtxoCount ?? "-"}
+              </span>
+            </li>
+            {((currentBalance?.matureUtxoCount ?? 0) > 0 ||
+              (currentBalance?.pendingUtxoCount ?? 0) > 0) && (
+              <li>
+                <strong>Status:</strong>{" "}
+                <span className="status">
+                  {!currentBalance?.matureUtxoCount
+                    ? "Initializing..."
+                    : "Ready"}
+                </span>
+              </li>
+            )}
+          </ul>
+          <UtxoCompound onFrozenBalanceChange={setFrozenBalance} />
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/Modals/WalletInfo.tsx
+++ b/src/components/Modals/WalletInfo.tsx
@@ -1,4 +1,5 @@
 import { useWalletStore } from "../../store/wallet.store";
+import { UtxoCompound } from "./UtxoCompound";
 
 export const WalletInfo = () => {
   const unlockedWalletName = useWalletStore(
@@ -67,6 +68,7 @@ export const WalletInfo = () => {
             </span>
           </li>
         </ul>
+        <UtxoCompound />
       </div>
     </div>
   );

--- a/src/components/Modals/WalletInfo.tsx
+++ b/src/components/Modals/WalletInfo.tsx
@@ -29,62 +29,44 @@ export const WalletInfo = () => {
   return (
     <div className="m-2 sm:m-4">
       <div className="border-kas-secondary bg-kas-secondary/5 mb-4 rounded-2xl border p-4">
-        <h4 className="text-kas-secondary font-bold">Wallet Name:</h4>
-        <div className="text-base font-semibold">{unlockedWalletName}</div>
-      </div>
-
-      <div className="border-primary-border bg-primary-bg mb-4 rounded-2xl border p-4">
-        <h4 className="mb-2 font-bold">Balance</h4>
-        <ul className="m-0 list-none p-0 text-base">
-          <li>
-            <strong>Total:</strong>{" "}
+        <div className="mb-2 flex flex-col items-center sm:flex-row sm:justify-start">
+          <h4 className="text-text-primary me-2 font-bold">Wallet Name:</h4>
+          <div className="text-base font-semibold">{unlockedWalletName}</div>
+        </div>
+        <div className="flex flex-col items-center sm:flex-row sm:justify-start">
+          <h4 className="text-text-primary me-2 font-bold">Balance:</h4>
+          <div>
             <span className="font-semibold text-[var(--accent-green)]">
               {currentBalance?.matureDisplay} KAS
             </span>
-          </li>
-          <li>
-            <strong>Confirmed:</strong>{" "}
-            <span className="font-semibold text-[var(--accent-green)]">
-              {currentBalance?.matureDisplay} KAS
-            </span>
-          </li>
-          <li>
-            <strong>Unconfirmed:</strong>{" "}
-            <span className="font-semibold text-[var(--accent-green)]">
-              {currentBalance?.pendingDisplay} KAS
-            </span>
-          </li>
-          <li>
-            <strong>Outgoing:</strong>{" "}
-            <span className="font-semibold text-[var(--accent-green)]">
-              {currentBalance?.outgoingDisplay} KAS
-            </span>
-          </li>
-        </ul>
+          </div>
+        </div>
       </div>
 
       {!frozenBalance &&
         ((currentBalance?.matureUtxoCount ?? 0) > 0 ||
           (currentBalance?.pendingUtxoCount ?? 0) > 0) && (
           <div className="border-primary-border bg-primary-bg mb-4 rounded-2xl border p-4">
-            <h4 className="mb-2 font-bold">UTXO Information</h4>
+            <h4 className="text-text-primary mb-2 text-center font-bold sm:text-left">
+              UTXO Information
+            </h4>
             <ul className="my-0 flex list-none flex-col gap-1 p-0 text-sm">
-              <li>
-                <strong>Mature UTXOs:</strong>{" "}
+              <li className="flex flex-col items-center sm:flex-row sm:justify-start">
+                <strong className="me-2">Mature UTXOs:</strong>{" "}
                 <span className="rounded-xl bg-[var(--kas-primary)] px-2 font-bold text-[var(--text-primary)]">
                   {currentBalance?.matureUtxoCount ?? "-"}
                 </span>
               </li>
-              <li>
-                <strong>Pending UTXOs:</strong>{" "}
+              <li className="flex flex-col items-center sm:flex-row sm:justify-start">
+                <strong className="me-2">Pending UTXOs:</strong>{" "}
                 <span className="rounded-xl bg-[var(--kas-primary)] px-2 font-bold text-[var(--text-primary)]">
                   {currentBalance?.pendingUtxoCount ?? "-"}
                 </span>
               </li>
               {((currentBalance?.matureUtxoCount ?? 0) > 0 ||
                 (currentBalance?.pendingUtxoCount ?? 0) > 0) && (
-                <li>
-                  <strong>Status:</strong>{" "}
+                <li className="flex flex-col items-center sm:flex-row sm:justify-start">
+                  <strong className="me-2">Status:</strong>{" "}
                   <span className="status">
                     {!currentBalance?.matureUtxoCount
                       ? "Initializing..."

--- a/src/components/Modals/WalletInfo.tsx
+++ b/src/components/Modals/WalletInfo.tsx
@@ -1,16 +1,33 @@
+import { useState } from "react";
 import { useWalletStore } from "../../store/wallet.store";
 import { UtxoCompound } from "./UtxoCompound";
 
+type FrozenBalance = {
+  matureUtxoCount: number;
+  matureDisplay: string;
+};
+
 export const WalletInfo = () => {
+  const [frozenBalance, setFrozenBalance] = useState<FrozenBalance | null>(
+    null
+  );
+
   const unlockedWalletName = useWalletStore(
     (state) => state.unlockedWallet?.name
   );
   const walletBalance = useWalletStore((s) => s.balance);
 
-  const currentBalance = walletBalance;
+  // use frozen balance if available, otherwise use current balance
+  const currentBalance = frozenBalance
+    ? {
+        ...walletBalance,
+        matureUtxoCount: frozenBalance.matureUtxoCount,
+        matureDisplay: frozenBalance.matureDisplay,
+      }
+    : walletBalance;
 
   return (
-    <div className="m-4">
+    <div className="m-2 sm:m-4">
       <div className="border-kas-secondary bg-kas-secondary/5 mb-4 rounded-2xl border p-4">
         <h4 className="text-kas-secondary font-bold">Wallet Name:</h4>
         <div className="text-base font-semibold">{unlockedWalletName}</div>
@@ -18,28 +35,28 @@ export const WalletInfo = () => {
 
       <div className="border-primary-border bg-primary-bg mb-4 rounded-2xl border p-4">
         <h4 className="mb-2 font-bold">Balance</h4>
-        <ul className="m-0 list-none p-0 text-sm">
+        <ul className="m-0 list-none p-0 text-base">
           <li>
             <strong>Total:</strong>{" "}
-            <span className="text-[var(--accent-green)]">
+            <span className="font-semibold text-[var(--accent-green)]">
               {currentBalance?.matureDisplay} KAS
             </span>
           </li>
           <li>
             <strong>Confirmed:</strong>{" "}
-            <span className="text-[var(--accent-green)]">
+            <span className="font-semibold text-[var(--accent-green)]">
               {currentBalance?.matureDisplay} KAS
             </span>
           </li>
           <li>
             <strong>Unconfirmed:</strong>{" "}
-            <span className="text-[var(--accent-green)]">
+            <span className="font-semibold text-[var(--accent-green)]">
               {currentBalance?.pendingDisplay} KAS
             </span>
           </li>
           <li>
             <strong>Outgoing:</strong>{" "}
-            <span className="text-[var(--accent-green)]">
+            <span className="font-semibold text-[var(--accent-green)]">
               {currentBalance?.outgoingDisplay} KAS
             </span>
           </li>
@@ -48,7 +65,7 @@ export const WalletInfo = () => {
 
       <div className="border-primary-border bg-primary-bg mb-4 rounded-2xl border p-4">
         <h4 className="mb-2 font-bold">UTXO Information</h4>
-        <ul className="m-0 list-none p-0 text-sm">
+        <ul className="my-0 flex list-none flex-col gap-1 p-0 text-sm">
           <li>
             <strong>Mature UTXOs:</strong>{" "}
             <span className="rounded-xl bg-[var(--kas-primary)] px-2 font-bold text-[var(--text-primary)]">
@@ -68,7 +85,7 @@ export const WalletInfo = () => {
             </span>
           </li>
         </ul>
-        <UtxoCompound />
+        <UtxoCompound onFrozenBalanceChange={setFrozenBalance} />
       </div>
     </div>
   );

--- a/src/components/Modals/WalletInfo.tsx
+++ b/src/components/Modals/WalletInfo.tsx
@@ -63,38 +63,39 @@ export const WalletInfo = () => {
         </ul>
       </div>
 
-      {((currentBalance?.matureUtxoCount ?? 0) > 0 ||
-        (currentBalance?.pendingUtxoCount ?? 0) > 0) && (
-        <div className="border-primary-border bg-primary-bg mb-4 rounded-2xl border p-4">
-          <h4 className="mb-2 font-bold">UTXO Information</h4>
-          <ul className="my-0 flex list-none flex-col gap-1 p-0 text-sm">
-            <li>
-              <strong>Mature UTXOs:</strong>{" "}
-              <span className="rounded-xl bg-[var(--kas-primary)] px-2 font-bold text-[var(--text-primary)]">
-                {currentBalance?.matureUtxoCount ?? "-"}
-              </span>
-            </li>
-            <li>
-              <strong>Pending UTXOs:</strong>{" "}
-              <span className="rounded-xl bg-[var(--kas-primary)] px-2 font-bold text-[var(--text-primary)]">
-                {currentBalance?.pendingUtxoCount ?? "-"}
-              </span>
-            </li>
-            {((currentBalance?.matureUtxoCount ?? 0) > 0 ||
-              (currentBalance?.pendingUtxoCount ?? 0) > 0) && (
+      {!frozenBalance &&
+        ((currentBalance?.matureUtxoCount ?? 0) > 0 ||
+          (currentBalance?.pendingUtxoCount ?? 0) > 0) && (
+          <div className="border-primary-border bg-primary-bg mb-4 rounded-2xl border p-4">
+            <h4 className="mb-2 font-bold">UTXO Information</h4>
+            <ul className="my-0 flex list-none flex-col gap-1 p-0 text-sm">
               <li>
-                <strong>Status:</strong>{" "}
-                <span className="status">
-                  {!currentBalance?.matureUtxoCount
-                    ? "Initializing..."
-                    : "Ready"}
+                <strong>Mature UTXOs:</strong>{" "}
+                <span className="rounded-xl bg-[var(--kas-primary)] px-2 font-bold text-[var(--text-primary)]">
+                  {currentBalance?.matureUtxoCount ?? "-"}
                 </span>
               </li>
-            )}
-          </ul>
-          <UtxoCompound onFrozenBalanceChange={setFrozenBalance} />
-        </div>
-      )}
+              <li>
+                <strong>Pending UTXOs:</strong>{" "}
+                <span className="rounded-xl bg-[var(--kas-primary)] px-2 font-bold text-[var(--text-primary)]">
+                  {currentBalance?.pendingUtxoCount ?? "-"}
+                </span>
+              </li>
+              {((currentBalance?.matureUtxoCount ?? 0) > 0 ||
+                (currentBalance?.pendingUtxoCount ?? 0) > 0) && (
+                <li>
+                  <strong>Status:</strong>{" "}
+                  <span className="status">
+                    {!currentBalance?.matureUtxoCount
+                      ? "Initializing..."
+                      : "Ready"}
+                  </span>
+                </li>
+              )}
+            </ul>
+            <UtxoCompound onFrozenBalanceChange={setFrozenBalance} />
+          </div>
+        )}
     </div>
   );
 };

--- a/src/components/Modals/WalletInfo.tsx
+++ b/src/components/Modals/WalletInfo.tsx
@@ -43,41 +43,42 @@ export const WalletInfo = () => {
         </div>
       </div>
 
-      {!frozenBalance &&
-        ((currentBalance?.matureUtxoCount ?? 0) > 0 ||
-          (currentBalance?.pendingUtxoCount ?? 0) > 0) && (
-          <div className="border-primary-border bg-primary-bg mb-4 rounded-2xl border p-4">
-            <h4 className="text-text-primary mb-2 text-center font-bold sm:text-left">
-              UTXO Information
-            </h4>
-            <ul className="my-0 flex list-none flex-col gap-1 p-0 text-sm">
+      {((currentBalance?.matureUtxoCount ?? 0) > 0 ||
+        (currentBalance?.pendingUtxoCount ?? 0) > 0) && (
+        <div className="border-primary-border bg-primary-bg mb-4 rounded-2xl border p-4">
+          <h4 className="text-text-primary mb-2 text-center font-bold sm:text-left">
+            UTXO Information
+          </h4>
+          <ul className="my-0 flex list-none flex-col gap-1 p-0 text-sm">
+            <li className="flex flex-col items-center sm:flex-row sm:justify-start">
+              <strong className="me-2">Mature UTXOs:</strong>{" "}
+              <span className="rounded-xl bg-[var(--kas-primary)] px-2 font-bold text-[var(--text-primary)]">
+                {frozenBalance?.matureUtxoCount ??
+                  currentBalance?.matureUtxoCount ??
+                  "-"}
+              </span>
+            </li>
+            <li className="flex flex-col items-center sm:flex-row sm:justify-start">
+              <strong className="me-2">Pending UTXOs:</strong>{" "}
+              <span className="rounded-xl bg-[var(--kas-primary)] px-2 font-bold text-[var(--text-primary)]">
+                {currentBalance?.pendingUtxoCount ?? "-"}
+              </span>
+            </li>
+            {((currentBalance?.matureUtxoCount ?? 0) > 0 ||
+              (currentBalance?.pendingUtxoCount ?? 0) > 0) && (
               <li className="flex flex-col items-center sm:flex-row sm:justify-start">
-                <strong className="me-2">Mature UTXOs:</strong>{" "}
-                <span className="rounded-xl bg-[var(--kas-primary)] px-2 font-bold text-[var(--text-primary)]">
-                  {currentBalance?.matureUtxoCount ?? "-"}
+                <strong className="me-2">Status:</strong>{" "}
+                <span className="status">
+                  {!currentBalance?.matureUtxoCount
+                    ? "Initializing..."
+                    : "Ready"}
                 </span>
               </li>
-              <li className="flex flex-col items-center sm:flex-row sm:justify-start">
-                <strong className="me-2">Pending UTXOs:</strong>{" "}
-                <span className="rounded-xl bg-[var(--kas-primary)] px-2 font-bold text-[var(--text-primary)]">
-                  {currentBalance?.pendingUtxoCount ?? "-"}
-                </span>
-              </li>
-              {((currentBalance?.matureUtxoCount ?? 0) > 0 ||
-                (currentBalance?.pendingUtxoCount ?? 0) > 0) && (
-                <li className="flex flex-col items-center sm:flex-row sm:justify-start">
-                  <strong className="me-2">Status:</strong>{" "}
-                  <span className="status">
-                    {!currentBalance?.matureUtxoCount
-                      ? "Initializing..."
-                      : "Ready"}
-                  </span>
-                </li>
-              )}
-            </ul>
-            <UtxoCompound onFrozenBalanceChange={setFrozenBalance} />
-          </div>
-        )}
+            )}
+          </ul>
+          <UtxoCompound onFrozenBalanceChange={setFrozenBalance} />
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/Modals/WalletWithdrawal.tsx
+++ b/src/components/Modals/WalletWithdrawal.tsx
@@ -1,5 +1,4 @@
 import { ChangeEvent, FC, useCallback, useState } from "react";
-import { createWithdrawTransaction } from "../../service/account-service";
 import { kaspaToSompi, sompiToKaspaString } from "kaspa-wasm";
 import { useWalletStore } from "../../store/wallet.store";
 import { Button } from "../Common/Button";
@@ -7,6 +6,7 @@ import { toast } from "../../utils/toast-helper";
 import { QrScanner } from "../QrScanner";
 import { Clipboard } from "lucide-react";
 import { useUiStore } from "../../store/ui.store";
+import { Address, FeeSource } from "kaspa-wasm";
 
 const maxDustAmount = kaspaToSompi("0.19")!;
 
@@ -19,7 +19,9 @@ export const WalletWithdrawal: FC = () => {
 
   const closeModal = useUiStore((s) => s.closeModal);
 
+  const accountService = useWalletStore((store) => store.accountService);
   const balance = useWalletStore((store) => store.balance);
+
   const inputAmountUpdated = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
       if (/^-?\d*\.?\d*$/.test(event.target.value) === false) {
@@ -88,6 +90,10 @@ export const WalletWithdrawal: FC = () => {
     try {
       setIsSending(true);
 
+      if (!accountService) {
+        return;
+      }
+
       if (!withdrawAddress || !withdrawAmount) {
         throw new Error("Please enter both Address and Amount");
       }
@@ -116,7 +122,12 @@ export const WalletWithdrawal: FC = () => {
         );
       }
 
-      await createWithdrawTransaction(withdrawAddress, amount);
+      const txId = await accountService.createWithdrawTransaction({
+        address: new Address(withdrawAddress),
+        amount: amount,
+        priorityFee: { amount: BigInt(0), source: FeeSource.SenderPays },
+      }); //withdrawAddress, amount);
+      console.log(`UTXO Compounding succeed, txid: ${txId}`);
       setWithdrawAddress("");
       setWithdrawAmount("");
       toast.success("Withdraw Success");

--- a/src/components/SendPaymentPopup.tsx
+++ b/src/components/SendPaymentPopup.tsx
@@ -109,15 +109,12 @@ export const SendPaymentPopup: FC<{
         .join("");
 
       // Send payment directly to recipient with message payload using new method
-      const txId = await walletStore.accountService.createPaymentWithMessage(
-        {
-          address: new Address(recipientAddress),
-          amount: amountSompi,
-          payload: payloadHex,
-          originalMessage: message, // Pass the original message for outgoing record
-        },
-        walletStore.unlockedWallet.password
-      );
+      const txId = await walletStore.accountService.createPaymentWithMessage({
+        address: new Address(recipientAddress),
+        amount: amountSompi,
+        payload: payloadHex,
+        originalMessage: message, // Pass the original message for outgoing record
+      });
 
       // Create and store outgoing payment message record (simplified)
       const paymentContent = JSON.stringify({

--- a/src/components/SendPaymentPopup.tsx
+++ b/src/components/SendPaymentPopup.tsx
@@ -99,14 +99,8 @@ export const SendPaymentPopup: FC<{
         throw new Error("Failed to encrypt payment message");
       }
 
-      // Create the simplified payment protocol payload (no alias needed)
-      const payload = `${PROTOCOL.prefix.string}${PROTOCOL.headers.PAYMENT.string}${encryptedMessage.to_hex()}`;
-
-      // Convert the payload to hex
-      const payloadHex = payload
-        .split("")
-        .map((c) => c.charCodeAt(0).toString(16).padStart(2, "0"))
-        .join("");
+      // Create the payment protocol payload using HEX headers (not string headers)
+      const payloadHex = `${PROTOCOL.prefix.hex}${PROTOCOL.headers.PAYMENT.hex}${encryptedMessage.to_hex()}`;
 
       // Send payment directly to recipient with message payload using new method
       const txId = await walletStore.accountService.createPaymentWithMessage({

--- a/src/containers/MessagesSection.tsx
+++ b/src/containers/MessagesSection.tsx
@@ -430,7 +430,7 @@ export const MessageSection: FC<{
           </div>
 
           <div
-            className="bg-primary-bg flex-1 overflow-x-hidden overflow-y-auto p-4 pb-8"
+            className="bg-primary-bg flex-1 overflow-x-hidden overflow-y-auto px-1 py-4 pb-8 sm:px-2"
             ref={messagesScrollRef}
           >
             <MessagesList

--- a/src/hooks/MessageComposer/useFeeEstimate.ts
+++ b/src/hooks/MessageComposer/useFeeEstimate.ts
@@ -24,7 +24,8 @@ export const useFeeEstimate = ({
     priority,
     sendState: { status: sendStatus },
   } = useComposerStore();
-  const { unlockedWallet, estimateSendMessageFees, address } = useWalletStore();
+  const { unlockedWallet, estimateSendMessageFees, address, balance } =
+    useWalletStore();
 
   useEffect(() => {
     // when toSelf is true, we need user's address; otherwise we need recipient
@@ -37,6 +38,15 @@ export const useFeeEstimate = ({
       sendStatus === "loading"
     ) {
       setFeeState({ status: "idle" });
+      return;
+    }
+
+    // check if we have funds available
+    if (!balance || balance.mature === 0n) {
+      setFeeState({
+        status: "error",
+        error: new Error("No funds available for fee estimation"),
+      });
       return;
     }
 
@@ -88,6 +98,7 @@ export const useFeeEstimate = ({
     sendStatus,
     unlockedWallet,
     estimateSendMessageFees,
+    balance,
   ]);
 
   return feeState;

--- a/src/hooks/MessageComposer/useFeeEstimate.ts
+++ b/src/hooks/MessageComposer/useFeeEstimate.ts
@@ -8,6 +8,7 @@ import { Address } from "kaspa-wasm";
 import { FeeState } from "../../types/all";
 
 export const useFeeEstimate = (
+  toSelf?: boolean,
   recipient?: string,
   draft?: string,
   attachment?: Attachment
@@ -18,11 +19,14 @@ export const useFeeEstimate = (
     priority,
     sendState: { status: sendStatus },
   } = useComposerStore();
-  const { unlockedWallet, estimateSendMessageFees } = useWalletStore();
+  const { unlockedWallet, estimateSendMessageFees, address } = useWalletStore();
 
   useEffect(() => {
+    // when toSelf is true, we need user's address; otherwise we need recipient
+    const targetAddress = toSelf ? address?.toString() : recipient;
+
     if (
-      !recipient ||
+      !targetAddress ||
       (!draft && !attachment) ||
       !unlockedWallet ||
       sendStatus === "loading"
@@ -31,13 +35,13 @@ export const useFeeEstimate = (
       return;
     }
 
-    let address: Address;
+    let parsedAddress: Address;
     try {
-      address = new Address(recipient);
+      parsedAddress = new Address(targetAddress);
     } catch {
       setFeeState({
         status: "error",
-        error: new Error("Invalid recipient address"),
+        error: new Error("Invalid address"),
       });
       return;
     }
@@ -50,7 +54,7 @@ export const useFeeEstimate = (
       // use attachment content if available, otherwise use draft text
       const messageContent = attachment ? attachment.content : draft || "";
 
-      estimateSendMessageFees(messageContent, address, priority)
+      estimateSendMessageFees(messageContent, parsedAddress, priority)
         .then((estimate) => {
           if (!isCancelled) {
             const fee = Number(estimate.fees) / 100_000_000;
@@ -70,7 +74,9 @@ export const useFeeEstimate = (
       clearTimeout(timeoutId);
     };
   }, [
+    toSelf,
     recipient,
+    address,
     draft,
     attachment,
     priority,

--- a/src/hooks/MessageComposer/useFeeEstimate.ts
+++ b/src/hooks/MessageComposer/useFeeEstimate.ts
@@ -7,12 +7,17 @@ import { useWalletStore } from "../../store/wallet.store";
 import { Address } from "kaspa-wasm";
 import { FeeState } from "../../types/all";
 
-export const useFeeEstimate = (
-  toSelf?: boolean,
-  recipient?: string,
-  draft?: string,
-  attachment?: Attachment
-) => {
+export const useFeeEstimate = ({
+  toSelf = false,
+  recipient,
+  draft,
+  attachment,
+}: {
+  toSelf?: boolean;
+  recipient?: string;
+  draft?: string;
+  attachment?: Attachment;
+}) => {
   const [feeState, setFeeState] = useState<FeeState>({ status: "idle" });
 
   const {

--- a/src/service/account-service.ts
+++ b/src/service/account-service.ts
@@ -538,7 +538,6 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
   }
 
   public async createWithdrawTransaction(
-    // remove the external below and follow payment or compound approacgh
     withdrawTransaction: CreateWithdrawTransactionArgs
   ) {
     this.validateTransactionPrerequisites();
@@ -565,7 +564,7 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
     }
 
     try {
-      const matureBalance = this.context.balance?.mature ?? 0n;
+      const matureBalance = this.context.balance?.mature;
       const isFullBalance = matureBalance === withdrawTransaction.amount;
       // Use our optimized generator creation method
       const generator = TransactionGeneratorService.createForPaymentOrWithdraw({
@@ -630,8 +629,8 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
     }
 
     try {
-      const balance = this.context.balance;
-      if (!balance || balance.mature === 0n) {
+      const matureBalance = this.context.balance?.mature;
+      if (!matureBalance || matureBalance === 0n) {
         throw new Error("No mature UTXOs available for compound transaction");
       }
 
@@ -827,7 +826,7 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
 
     console.log(`Added prefix to address: ${prefixedAddressString}`);
     return new Address(prefixedAddressString);
-  }
+  } // TODO Utility
 
   private isKasiaTransaction(tx: ITransaction | ExplorerTransaction): boolean {
     return tx?.payload?.startsWith(PROTOCOL.prefix.hex) ?? false;
@@ -1221,46 +1220,3 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
     }
   }
 }
-
-export const createWithdrawTransaction = async (
-  toAddress: string,
-  amountSompi: bigint
-): Promise<void> => {
-  try {
-    console.log("Sending withdraw transaction:", {
-      toAddress,
-      amountSompi,
-    });
-
-    const walletStore = useWalletStore.getState();
-    const accountService = walletStore.accountService;
-    const password = walletStore.unlockedWallet?.password;
-
-    if (!accountService) {
-      throw new Error("Account service not initialized");
-    }
-
-    if (!password) {
-      throw new Error("Wallet is locked. Please unlock your wallet first.");
-    }
-
-    // Create and send a native transaction (no payload)
-    await accountService.createWithdrawTransaction(
-      {
-        address: new Address(toAddress),
-        amount: amountSompi,
-        priorityFee: { amount: BigInt(0), source: FeeSource.ReceiverPays },
-      },
-      password
-    );
-
-    console.log("Withdraw transaction sent successfully");
-  } catch (error) {
-    console.error("Send withdraw transaction error:", error);
-    throw new Error(
-      error instanceof Error
-        ? error.message
-        : "Failed to send withdraw transaction"
-    );
-  }
-};

--- a/src/service/account-service.ts
+++ b/src/service/account-service.ts
@@ -295,7 +295,7 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
       console.log("Successfully subscribed to block events");
 
       // Get initial state one more time to ensure we're up to date
-      this._emitBalanceUpdate();
+      // this._emitBalanceUpdate();
 
       this.isStarted = true;
     } catch (error) {
@@ -522,10 +522,6 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
 
       console.log(`Payment with message submitted with ID: ${txId}`);
 
-      // Reset the context to trigger immediate balance update
-      await this.context.clear();
-      await this.context.trackAddresses([this.receiveAddress!]);
-
       return txId;
     } catch (error) {
       console.error("Error creating payment with message:", error);
@@ -605,11 +601,6 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
       // submit
       const txId: string = await pendingTransaction.submit(this.rpcClient.rpc);
 
-      // reset the context to workaround "withdraw all" use-case where change address isn't the user
-      // @IMPROVEMENT: this could be only executed when "withdraw all", currently done even if it's partial
-      await this.context.clear();
-      await this.context.trackAddresses([this.receiveAddress!]);
-
       console.log(`Transaction submitted with ID: ${txId}`);
 
       return txId;
@@ -647,10 +638,6 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
     }
 
     try {
-      // refresh the UTXO context to ensure we have the latest UTXO data
-      await this.context.clear();
-      await this.context.trackAddresses([this.receiveAddress!]);
-
       const balance = this.context.balance;
       if (!balance || balance.mature === 0n) {
         throw new Error("No mature UTXOs available for compound transaction");
@@ -693,10 +680,6 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
       const txId: string = await pendingTransaction.submit(this.rpcClient.rpc);
 
       console.log(`Transaction submitted with ID: ${txId}`);
-
-      // wait for transaction to propagate, then refresh context
-      await new Promise((resolve) => setTimeout(resolve, 500));
-      this._emitBalanceUpdate();
 
       return txId;
     } catch (error) {

--- a/src/service/account-service.ts
+++ b/src/service/account-service.ts
@@ -3,8 +3,6 @@ import {
   Address,
   UtxoProcessor,
   UtxoContext,
-  Generator,
-  PaymentOutput,
   UtxoEntry,
   ITransaction,
   PendingTransaction,
@@ -45,6 +43,7 @@ import {
   tryParseBase64AsHexToHex,
 } from "../utils/payload-encoding";
 import { WalletStorageService } from "./wallet-storage-service";
+import { TransactionGeneratorService } from "./transaction-generator";
 import { MAX_TX_FEE } from "../config/constants";
 
 // strictly typed events
@@ -375,7 +374,15 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
 
     try {
       // Use our optimized generator creation method
-      const generator = this._getGeneratorForTransaction(transaction);
+      const generator = TransactionGeneratorService.createForTransaction({
+        context: this.context,
+        networkId: this.networkId,
+        receiveAddress: this.receiveAddress!,
+        destinationAddress: transaction.address,
+        amount: transaction.amount,
+        payload: transaction.payload,
+        priorityFee: transaction.priorityFee,
+      });
 
       console.log("Generating transaction...");
       const pendingTransaction: PendingTransaction | null =
@@ -451,26 +458,6 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
       throw new Error("Transaction amount is required");
     }
 
-    console.log("=== CREATING PAYMENT WITH MESSAGE ===");
-    const primaryAddress = this.receiveAddress;
-    console.log(
-      "Creating payment from primary address:",
-      primaryAddress.toString()
-    );
-    console.log(
-      "Change will go back to primary address:",
-      primaryAddress.toString()
-    );
-    console.log(`Destination: ${paymentTransaction.address.toString()}`);
-    console.log(
-      `Amount: ${Number(paymentTransaction.amount) / 100000000} KAS (${
-        paymentTransaction.amount
-      } sompi)`
-    );
-    console.log(
-      `Payload length: ${paymentTransaction.payload.length / 2} bytes`
-    );
-
     const privateKeyGenerator = WalletStorageService.getPrivateKeyGenerator(
       this.unlockedWallet,
       password
@@ -486,10 +473,16 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
 
     try {
       // Use a modified generator that sends to recipient but includes payload
-      const generator =
-        await this._getGeneratorForPaymentWithMessage(paymentTransaction);
+      const generator = TransactionGeneratorService.createForPaymentOrWithdraw({
+        context: this.context,
+        networkId: this.networkId,
+        receiveAddress: this.receiveAddress!,
+        destinationAddress: paymentTransaction.address,
+        amount: paymentTransaction.amount,
+        payload: paymentTransaction.payload,
+        priorityFee: paymentTransaction.priorityFee,
+      });
 
-      console.log("Generating payment transaction...");
       const pendingTransaction: PendingTransaction | null =
         await generator.next();
 
@@ -512,7 +505,6 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
 
       // Always use receive key for all addresses since we only use primary address
       const privateKeys = pendingTransaction.addresses().map(() => {
-        console.log("Using primary address key for signing");
         const key = privateKeyGenerator.receiveKey(0);
         if (!key) {
           throw new Error("Failed to generate private key for signing");
@@ -521,7 +513,6 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
       });
 
       // Sign the transaction
-      console.log("Signing transaction...");
       pendingTransaction.sign(privateKeys);
 
       // Submit the transaction
@@ -562,22 +553,6 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
       throw new Error("Transaction amount is required");
     }
 
-    console.log("=== CREATING WITHDRAW TRANSACTION ===");
-    const primaryAddress = this.receiveAddress;
-    console.log(
-      "Creating withdraw transaction from primary address:",
-      primaryAddress.toString()
-    );
-    console.log(
-      "Change will go back to primary address:",
-      primaryAddress.toString()
-    );
-    console.log(`Destination: ${withdrawTransaction.address.toString()}`);
-    console.log(
-      `Amount: ${Number(withdrawTransaction.amount) / 100000000} KAS (${
-        withdrawTransaction.amount
-      } sompi)`
-    );
     const privateKeyGenerator = WalletStorageService.getPrivateKeyGenerator(
       this.unlockedWallet,
       password
@@ -593,10 +568,15 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
 
     try {
       // Use our optimized generator creation method
-      const generator =
-        this._getGeneratorForWithdrawTransaction(withdrawTransaction);
+      const generator = TransactionGeneratorService.createForPaymentOrWithdraw({
+        context: this.context,
+        networkId: this.networkId,
+        receiveAddress: this.receiveAddress!,
+        destinationAddress: withdrawTransaction.address,
+        amount: withdrawTransaction.amount,
+        priorityFee: withdrawTransaction.priorityFee,
+      });
 
-      console.log("Generating transaction...");
       const pendingTransaction: PendingTransaction | null =
         await generator.next();
 
@@ -606,16 +586,13 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
 
       // Log the addresses that need signing
       const addressesToSign = pendingTransaction.addresses();
-      console.log(
-        `Transaction requires signing ${addressesToSign.length} addresses:`
-      );
+
       addressesToSign.forEach((addr, i) => {
         console.log(`  Address ${i + 1}: ${addr.toString()}`);
       });
 
       // Always use receive key for all addresses since we only use primary address
       const privateKeys = pendingTransaction.addresses().map(() => {
-        console.log("Using primary address key for signing");
         const key = privateKeyGenerator.receiveKey(0);
         if (!key) {
           throw new Error("Failed to generate private key for signing");
@@ -624,12 +601,8 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
       });
 
       // Sign the transaction
-      console.log("Signing transaction...");
       pendingTransaction.sign(privateKeys);
-
-      // Submit the transaction
-      console.log("Submitting transaction to network...");
-
+      // submit
       const txId: string = await pendingTransaction.submit(this.rpcClient.rpc);
 
       // reset the context to workaround "withdraw all" use-case where change address isn't the user
@@ -638,7 +611,6 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
       await this.context.trackAddresses([this.receiveAddress!]);
 
       console.log(`Transaction submitted with ID: ${txId}`);
-      console.log("========================");
 
       return txId;
     } catch (error) {
@@ -663,7 +635,6 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
     // ensure password is available
     this.ensurePasswordSet();
 
-    console.log("=== CREATING COMPOUND TRANSACTION ===");
     console.log("Consolidating all UTXOs to:", this.receiveAddress.toString());
 
     const privateKeyGenerator = WalletStorageService.getPrivateKeyGenerator(
@@ -680,17 +651,18 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
       await this.context.clear();
       await this.context.trackAddresses([this.receiveAddress!]);
 
-      // validate UTXO availability before creating transaction
-      console.log("Validating UTXO availability...");
       const balance = this.context.balance;
       if (!balance || balance.mature === 0n) {
         throw new Error("No mature UTXOs available for compound transaction");
       }
 
       // Use our simple compound transaction generator
-      const generator = this._getGeneratorForCompoundTransaction();
+      const generator = TransactionGeneratorService.createForCompound({
+        context: this.context,
+        networkId: this.networkId,
+        receiveAddress: this.receiveAddress!,
+      });
 
-      console.log("Generating transaction...");
       const pendingTransaction: PendingTransaction | null =
         await generator.next();
 
@@ -700,16 +672,13 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
 
       // Log the addresses that need signing
       const addressesToSign = pendingTransaction.addresses();
-      console.log(
-        `Transaction requires signing ${addressesToSign.length} addresses:`
-      );
+
       addressesToSign.forEach((addr, i) => {
         console.log(`  Address ${i + 1}: ${addr.toString()}`);
       });
 
       // Always use receive key for all addresses since we only use primary address
       const privateKeys = pendingTransaction.addresses().map(() => {
-        console.log("Using primary address key for signing");
         const key = privateKeyGenerator.receiveKey(0);
         if (!key) {
           throw new Error("Failed to generate private key for signing");
@@ -718,16 +687,12 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
       });
 
       // Sign the transaction
-      console.log("Signing transaction...");
       pendingTransaction.sign(privateKeys);
 
       // Submit the transaction
-      console.log("Submitting transaction to network...");
-
       const txId: string = await pendingTransaction.submit(this.rpcClient.rpc);
 
       console.log(`Transaction submitted with ID: ${txId}`);
-      console.log("========================");
 
       // wait for transaction to propagate, then refresh context
       await new Promise((resolve) => setTimeout(resolve, 500));
@@ -745,7 +710,15 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
       throw new Error("Account service is not started");
     }
 
-    return this._getGeneratorForTransaction(transaction).estimate();
+    return TransactionGeneratorService.createForTransaction({
+      context: this.context,
+      networkId: this.networkId,
+      receiveAddress: this.receiveAddress!,
+      destinationAddress: transaction.address,
+      amount: transaction.amount,
+      payload: transaction.payload,
+      priorityFee: transaction.priorityFee,
+    }).estimate();
   }
 
   public async sendMessage(
@@ -894,152 +867,6 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
 
     console.log(`Added prefix to address: ${prefixedAddressString}`);
     return new Address(prefixedAddressString);
-  }
-
-  private _getGeneratorForTransaction(transaction: CreateTransactionArgs) {
-    if (!this.isStarted) {
-      throw new Error("Account service is not started");
-    }
-
-    // Ensure both addresses have the correct prefixes
-    const destinationAddress = this.ensureAddressPrefix(transaction.address);
-    const primaryAddress = this.ensureAddressPrefix(this.receiveAddress!);
-
-    // Log both addresses for debugging
-    console.log("Using destination address:", destinationAddress.toString());
-    console.log("Using primary address for change:", primaryAddress.toString());
-
-    // Check if this is a direct self-message (sending to our own receive address)
-    const isDirectSelfMessage =
-      destinationAddress.toString() === this.receiveAddress?.toString();
-
-    console.log(isDirectSelfMessage);
-    // For regular transactions, always use the specified amount and destination
-    // For self-messages, use empty outputs array to only use change output
-    const outputs = isDirectSelfMessage
-      ? []
-      : [new PaymentOutput(destinationAddress, transaction.amount)];
-
-    // Calculate additional fee based on fee rate difference
-    let additionalFee = BigInt(0);
-
-    if (
-      transaction.priorityFee?.feerate &&
-      transaction.priorityFee.feerate > 1
-    ) {
-      // Estimate transaction mass (typical message transaction ~2500-3000 grams)
-      const estimatedMass = 2800; // grams - rough estimate for message transaction
-      const baseFeeRate = 1; // sompi per gram
-      const additionalFeeRate = transaction.priorityFee.feerate - baseFeeRate;
-      additionalFee = BigInt(Math.floor(additionalFeeRate * estimatedMass));
-
-      console.log("Calculated additional priority fee:", {
-        selectedFeeRate: transaction.priorityFee.feerate,
-        baseFeeRate,
-        additionalFeeRate,
-        estimatedMass,
-        additionalFeeSompi: additionalFee.toString(),
-        additionalFeeKAS: Number(additionalFee) / 100_000_000,
-      });
-    } else if (
-      transaction.priorityFee?.amount &&
-      transaction.priorityFee.amount > 0
-    ) {
-      additionalFee = transaction.priorityFee.amount;
-      console.log(
-        "Using explicit priority fee amount:",
-        additionalFee.toString()
-      );
-    }
-
-    console.log("Final priority fee for Generator:", additionalFee.toString());
-
-    return new Generator({
-      changeAddress: primaryAddress,
-      entries: this.context,
-      outputs: outputs,
-      payload: transaction.payload,
-      networkId: this.networkId,
-      priorityFee: additionalFee,
-    });
-  }
-
-  private async _getGeneratorForPaymentWithMessage(
-    transaction: CreatePaymentWithMessageArgs
-  ) {
-    const matureBalance = this.context.balance?.mature ?? 0n;
-
-    // if sending full balance, use ReceiverPays
-    const isFullBalance = transaction.amount >= matureBalance;
-
-    const changeAddress = isFullBalance
-      ? new Address(transaction.address.toString())
-      : this.receiveAddress!;
-
-    const priorityFee = isFullBalance
-      ? { amount: BigInt(0), source: FeeSource.ReceiverPays }
-      : transaction.priorityFee || {
-          amount: BigInt(0),
-          source: FeeSource.SenderPays,
-        };
-    // once we add custom fees we might need to bring back a estimate generator,
-    // but we at least wont be calling estimatetransaction functio extenally
-    return new Generator({
-      changeAddress,
-      entries: this.context,
-      outputs: [
-        new PaymentOutput(
-          new Address(transaction.address.toString()),
-          transaction.amount
-        ),
-      ],
-      networkId: this.networkId,
-      priorityFee,
-      payload: transaction.payload,
-    });
-  }
-
-  private _getGeneratorForCompoundTransaction() {
-    // compound transaction - sweep operation to consolidate UTXOs
-    // for compound tx, we pass undefined to outputs which means we dont need to specify priorty fee
-    return new Generator({
-      changeAddress: this.receiveAddress!,
-      entries: this.context,
-      outputs: undefined as unknown as PaymentOutput[],
-      networkId: this.networkId,
-    });
-  }
-
-  private _getGeneratorForWithdrawTransaction(
-    transaction: CreateWithdrawTransactionArgs
-  ) {
-    if (!this.isStarted) {
-      throw new Error("Account service is not started");
-    }
-
-    console.log("Using destination address:", transaction.address.toString());
-
-    const isFullBalance = transaction.amount === this.context.balance?.mature;
-
-    const changeAddress = isFullBalance
-      ? new Address(transaction.address.toString())
-      : this.receiveAddress!;
-
-    // for full balance, use ReceiverPays (no choice). For partial, use SenderPays
-    const priorityFee = isFullBalance
-      ? { amount: BigInt(0), source: FeeSource.ReceiverPays }
-      : transaction.priorityFee || {
-          amount: BigInt(0),
-          source: FeeSource.SenderPays,
-        };
-
-    return new Generator({
-      changeAddress,
-      entries: this.context,
-      outputs: [new PaymentOutput(transaction.address, transaction.amount)],
-      networkId: this.networkId,
-      priorityFee,
-    });
   }
 
   private isKasiaTransaction(tx: ITransaction | ExplorerTransaction): boolean {

--- a/src/service/account-service.ts
+++ b/src/service/account-service.ts
@@ -266,18 +266,16 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
         this.receiveAddress.toString()
       );
 
-      // Initialize UTXO processor first
-      console.log("Starting UTXO processor...");
-      await this.processor.start();
-
-      // Set up event listeners before doing anything else
+      // Set up event listeners
       console.log("Setting up event listeners...");
-
-      // Set up balance change listener
       this.processor.addEventListener("balance", async () => {
         console.log("Balance event received");
         this._emitBalanceUpdate();
       });
+
+      // start the processor
+      console.log("Starting UTXO processor...");
+      await this.processor.start();
 
       // Only track primary address
       const addressesToTrack = [this.receiveAddress!];
@@ -293,9 +291,6 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
         void this.processBlockEvent(event as unknown as BlockAddedData);
       });
       console.log("Successfully subscribed to block events");
-
-      // Get initial state one more time to ensure we're up to date
-      // this._emitBalanceUpdate();
 
       this.isStarted = true;
     } catch (error) {

--- a/src/service/account-service.ts
+++ b/src/service/account-service.ts
@@ -1165,7 +1165,7 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
     this.assertReady();
     return this.ctx.getMatureRange(0, this.ctx.matureLength);
   }
-=== Staging below
+  //=== Staging below
   private isKasiaTransaction(tx: ITransaction | ExplorerTransaction): boolean {
     return tx?.payload?.startsWith(PROTOCOL.prefix.hex) ?? false;
   }
@@ -1376,7 +1376,7 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
             console.debug(`Failed to decrypt with receive key:`, error);
           }
         }
-        === Staging ABOVE
+        //=== Staging ABOVE
         if (!decryptionSuccess) {
           try {
             const privateKey = privateKeyGenerator.changeKey(0);
@@ -1583,6 +1583,7 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
     }
   }
 
+  // note: account service should not be responsible for handling block added logic
   private async processBlockEvent(event: BlockAddedData) {
     try {
       const blockTime =
@@ -1597,6 +1598,9 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
         }
       });
 
+      // note: this should be optimized, account service shouldn't be the owner of that
+      // it shouldn't be needed to refresh computation here if the owner of this would be the
+      // maintainer of the shared state
       this.updateMonitoredConversations();
 
       for (const tx of transactions) {
@@ -1604,6 +1608,7 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
         if (!txId || this.processedMessageIds.has(txId)) continue;
 
         if (this.isKasiaTransaction(tx)) {
+          console.log("found a kasia transaction", { tx });
           // mark the txId as processed to avoid duplicate processing
           this.processedMessageIds.add(txId);
           if (this.processedMessageIds.size > this.MAX_PROCESSED_MESSAGES) {
@@ -1615,7 +1620,6 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
           }
 
           try {
-            // Process message transaction silently
             await this.processMessageTransaction(tx, blockTime);
           } catch (error) {
             if (process.env.NODE_ENV === "development") {

--- a/src/service/account-service.ts
+++ b/src/service/account-service.ts
@@ -249,21 +249,53 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
     return null;
   }
 
-  private validateTransactionPrerequisites() {
-    if (!this.isStarted || !this.rpcClient.rpc) {
+  // private validateTransactionPrerequisites() {
+  //   if (!this.isStarted || !this.rpcClient.rpc) {
+  //     throw new Error("Account service is not started");
+  //   }
+
+  //   if (!this.receiveAddress) {
+  //     throw new Error("Receive address not initialized");
+  //   }
+
+  //   if (!this.context) {
+  //     throw new Error("UTXO context not initialized");
+  //   }
+
+  //   // ensure password is available
+  //   this.ensurePasswordSet();
+  // }
+
+  private assertReady(): asserts this is AccountService & {
+    receiveAddress: Address;
+    context: UtxoContext;
+  } {
+    if (!this.isStarted || !this.rpcClient.rpc)
       throw new Error("Account service is not started");
-    }
-
-    if (!this.receiveAddress) {
+    if (!this.receiveAddress)
       throw new Error("Receive address not initialized");
-    }
+    if (!this.context) throw new Error("UTXO context not initialized");
+    if (!this.password)
+      throw new Error("Password not set - cannot perform operation");
+  }
 
-    if (!this.context) {
-      throw new Error("UTXO context not initialized");
-    }
-
-    // ensure password is available
-    this.ensurePasswordSet();
+  private get rpc() {
+    if (!this.rpcClient.rpc) throw new Error("RPC client is not initialized");
+    return this.rpcClient.rpc;
+  }
+  private get recv(): Address {
+    if (!this.receiveAddress)
+      throw new Error("Receive address not initialized");
+    return this.receiveAddress;
+  }
+  private get ctx(): UtxoContext {
+    if (!this.context) throw new Error("UTXO context not initialized");
+    return this.context;
+  }
+  private get pwd(): string {
+    if (!this.password)
+      throw new Error("Password not set - cannot perform operation");
+    return this.password;
   }
 
   async start() {
@@ -339,13 +371,7 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
     transaction: CreateTransactionArgs,
     password: string
   ): Promise<TransactionId> {
-    if (!this.isStarted || !this.rpcClient.rpc) {
-      throw new Error("Account service is not started");
-    }
-
-    if (!this.receiveAddress) {
-      throw new Error("Receive address not initialized");
-    }
+    this.assertReady();
 
     if (!transaction.address) {
       throw new Error("Transaction address is required");
@@ -356,7 +382,7 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
     }
 
     console.log("=== CREATING TRANSACTION ===");
-    const primaryAddress = this.receiveAddress;
+    const primaryAddress = this.recv;
     console.log(
       "Creating transaction from primary address:",
       primaryAddress.toString()
@@ -382,16 +408,12 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
       throw new Error("Failed to generate private key");
     }
 
-    if (!this.context) {
-      throw new Error("UTXO context not initialized");
-    }
-
     try {
       // Use our optimized generator creation method
       const generator = TransactionGeneratorService.createForTransaction({
-        context: this.context,
+        context: this.ctx,
         networkId: this.networkId,
-        receiveAddress: this.receiveAddress!,
+        receiveAddress: this.recv,
         destinationAddress: transaction.address,
         amount: transaction.amount,
         payload: transaction.payload,
@@ -441,7 +463,7 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
 
       // Submit the transaction
       console.log("Submitting transaction to network...");
-      const txId: string = await pendingTransaction.submit(this.rpcClient.rpc!);
+      const txId: string = await pendingTransaction.submit(this.rpc);
       console.log(`Transaction submitted with ID: ${txId}`);
       console.log("========================");
 
@@ -455,7 +477,7 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
   public async createPaymentWithMessage(
     paymentTransaction: CreatePaymentWithMessageArgs
   ): Promise<TransactionId> {
-    this.validateTransactionPrerequisites();
+    this.assertReady();
 
     if (!paymentTransaction.address) {
       throw new Error("Transaction address is required");
@@ -467,25 +489,21 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
 
     const privateKeyGenerator = WalletStorageService.getPrivateKeyGenerator(
       this.unlockedWallet,
-      this.password!
+      this.pwd
     );
 
     if (!privateKeyGenerator) {
       throw new Error("Failed to generate private key");
     }
 
-    if (!this.context) {
-      throw new Error("UTXO context not initialized");
-    }
-
     try {
-      const matureBalance = this.context.balance?.mature ?? 0n;
+      const matureBalance = this.ctx.balance?.mature ?? 0n;
       const isFullBalance = matureBalance === paymentTransaction.amount;
       // Use a modified generator that sends to recipient but includes payload
       const generator = TransactionGeneratorService.createForPaymentOrWithdraw({
-        context: this.context,
+        context: this.ctx,
         networkId: this.networkId,
-        receiveAddress: this.receiveAddress!,
+        receiveAddress: this.recv,
         destinationAddress: paymentTransaction.address,
         amount: paymentTransaction.amount,
         payload: paymentTransaction.payload,
@@ -528,7 +546,7 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
       // Submit the transaction
       console.log("Submitting transaction to network...");
 
-      const txId: string = await pendingTransaction.submit(this.rpcClient.rpc!);
+      const txId: string = await pendingTransaction.submit(this.rpc);
 
       console.log(`Payment with message submitted with ID: ${txId}`);
 
@@ -542,7 +560,7 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
   public async createWithdrawTransaction(
     withdrawTransaction: CreateWithdrawTransactionArgs
   ) {
-    this.validateTransactionPrerequisites();
+    this.assertReady();
 
     if (!withdrawTransaction.address) {
       throw new Error("Transaction address is required");
@@ -554,25 +572,21 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
 
     const privateKeyGenerator = WalletStorageService.getPrivateKeyGenerator(
       this.unlockedWallet,
-      this.password!
+      this.pwd
     );
 
     if (!privateKeyGenerator) {
       throw new Error("Failed to generate private key");
     }
 
-    if (!this.context) {
-      throw new Error("UTXO context not initialized");
-    }
-
     try {
-      const matureBalance = this.context.balance?.mature;
+      const matureBalance = this.ctx.balance?.mature;
       const isFullBalance = matureBalance === withdrawTransaction.amount;
       // Use our optimized generator creation method
       const generator = TransactionGeneratorService.createForPaymentOrWithdraw({
-        context: this.context,
+        context: this.ctx,
         networkId: this.networkId,
-        receiveAddress: this.receiveAddress!,
+        receiveAddress: this.recv,
         destinationAddress: withdrawTransaction.address,
         amount: withdrawTransaction.amount,
         priorityFee: withdrawTransaction.priorityFee,
@@ -605,7 +619,7 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
       // Sign the transaction
       pendingTransaction.sign(privateKeys);
       // submit
-      const txId: string = await pendingTransaction.submit(this.rpcClient.rpc!);
+      const txId: string = await pendingTransaction.submit(this.rpc);
 
       console.log(`Transaction submitted with ID: ${txId}`);
 
@@ -617,13 +631,13 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
   }
 
   public async createCompoundTransaction() {
-    this.validateTransactionPrerequisites();
+    this.assertReady();
 
-    console.log("Consolidating all UTXOs to:", this.receiveAddress!.toString());
+    console.log("Consolidating all UTXOs to:", this.recv.toString());
 
     const privateKeyGenerator = WalletStorageService.getPrivateKeyGenerator(
       this.unlockedWallet,
-      this.password!
+      this.pwd
     );
 
     if (!privateKeyGenerator) {
@@ -631,16 +645,16 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
     }
 
     try {
-      const matureBalance = this.context.balance?.mature;
+      const matureBalance = this.ctx.balance?.mature;
       if (!matureBalance || matureBalance === 0n) {
         throw new Error("No mature UTXOs available for compound transaction");
       }
 
       // Use our simple compound transaction generator
       const generator = TransactionGeneratorService.createForCompound({
-        context: this.context,
+        context: this.ctx,
         networkId: this.networkId,
-        receiveAddress: this.receiveAddress!,
+        receiveAddress: this.recv,
       });
 
       const pendingTransaction: PendingTransaction | null =
@@ -670,7 +684,7 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
       pendingTransaction.sign(privateKeys);
 
       // Submit the transaction
-      const txId: string = await pendingTransaction.submit(this.rpcClient.rpc!);
+      const txId: string = await pendingTransaction.submit(this.rpc);
 
       console.log(`Transaction submitted with ID: ${txId}`);
 
@@ -754,6 +768,8 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
   public async estimateSendMessageFees(
     sendMessage: EstimateSendMessageFeesArgs
   ): Promise<GeneratorSummary> {
+    this.assertReady();
+
     if (!sendMessage.toAddress) {
       throw new Error("Destination address is required");
     }
@@ -787,9 +803,9 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
 
     try {
       return TransactionGeneratorService.createForTransaction({
-        context: this.context,
+        context: this.ctx,
         networkId: this.networkId,
-        receiveAddress: this.receiveAddress!,
+        receiveAddress: this.recv,
         destinationAddress: destinationAddress,
         amount: BigInt(0.2 * 100_000_000),
         payload: payload,
@@ -802,11 +818,8 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
   }
 
   public getMatureUtxos() {
-    if (!this.isStarted) {
-      throw new Error("Account service is not started");
-    }
-
-    return this.context.getMatureRange(0, this.context.matureLength);
+    this.assertReady();
+    return this.ctx.getMatureRange(0, this.ctx.matureLength);
   }
 
   private isKasiaTransaction(tx: ITransaction | ExplorerTransaction): boolean {
@@ -967,12 +980,40 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
 
       try {
         const privateKey = privateKeyGenerator.receiveKey(0);
-
+======RESOLVE +
         const decryptedContent = decrypt_message(
           new EncryptedMessage(encryptedHex),
           new PrivateKey(privateKey.toString())
-        );
+      const parsed = parseKaspaMessagePayload(tx.payload);
+      let messageType = parsed.type;
+      const targetAlias = parsed.alias;
 
+      const hexEncryptedPayload = tryBase64ToHex(parsed.encryptedHex);
+
+      const encryptedHex = hexEncryptedPayload;
+      let isHandshake = parsed.type === PROTOCOL.headers.HANDSHAKE.type;
+
+      const isMonitoredAddress =
+        (senderAddress && this.monitoredAddresses.has(senderAddress)) ||
+        (recipientAddress && this.monitoredAddresses.has(recipientAddress));
+      const isCommForUs =
+        messageType === PROTOCOL.headers.COMM.type &&
+        targetAlias &&
+        this.monitoredConversations.has(targetAlias);
+
+      // For payments, check if the sender address is one we're monitoring
+      // (i.e., we have a conversation with them OR they sent us a payment)
+      const isPaymentForUs =
+        messageType === PROTOCOL.headers.PAYMENT.type &&
+        (isMonitoredAddress ||
+          recipientAddress === this.receiveAddress?.toString());
+
+      try {
+        const privateKeyGenerator = WalletStorageService.getPrivateKeyGenerator(
+          this.unlockedWallet,
+          this.pwd
+        );
+======RESOLVE +
         decryptionSuccess = true;
 
         if (decryptionSuccess) {
@@ -1044,12 +1085,7 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
   }
 
   public async sendMessageWithContext(sendMessage: SendMessageWithContextArgs) {
-    this.ensurePasswordSet();
-
-    // Ensure we have our receive address
-    if (!this.receiveAddress) {
-      throw new Error("Receive address not initialized");
-    }
+    this.assertReady();
 
     const minimumAmount = kaspaToSompi("0.2");
 
@@ -1091,9 +1127,9 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
 
     console.log("Encryption details:", {
       conversationPartnerAddress: conversationWithContact.contact.kaspaAddress,
-      ourAddress: this.receiveAddress?.toString(),
+      ourAddress: this.recv.toString(),
       theirAlias: sendMessage.theirAlias,
-      destinationAddress: this.receiveAddress?.toString(),
+      destinationAddress: this.recv.toString(),
       conversation: conversationWithContact,
     });
 
@@ -1110,7 +1146,7 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
 
     try {
       // Always send to our own address for self-send messages
-      const destinationAddress = new Address(this.receiveAddress.toString());
+      const destinationAddress = new Address(this.recv.toString());
       // Send to our own address
       const txId = await this.createTransaction(
         {

--- a/src/service/account-service.ts
+++ b/src/service/account-service.ts
@@ -723,6 +723,7 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
     }
   }
 
+  // estimation with context 1:1 base64
   public async estimateSendMessageFees(
     sendMessage: EstimateSendMessageFeesArgs
   ): Promise<GeneratorSummary> {
@@ -736,23 +737,20 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
 
     const destinationAddress = this.ensureAddressPrefix(sendMessage.toAddress);
     const addressString = destinationAddress.toString();
-
     // Message needs to be encrypted
+
     const encryptedMessage = encrypt_message(
       addressString,
       sendMessage.message
     );
-
+    const bytesData = hexToBytes(encryptedMessage.to_hex());
+    const base64Data = btoa(String.fromCharCode(...bytesData));
     if (!encryptedMessage) {
       throw new Error("Failed to encrypt message");
     }
-
-    const payload = `${PROTOCOL.prefix.string}${PROTOCOL.headers.COMM.string}${PLACEHOLDER_ALIAS}:${encryptedMessage.to_hex()}`;
-
-    const payloadHex = payload
-      .split("")
-      .map((c) => c.charCodeAt(0).toString(16).padStart(2, "0"))
-      .join("");
+    // Build the full protocol string with all components to match sendMessageWithContext
+    const protocolString = `ciph_msg:1:comm:${PLACEHOLDER_ALIAS}:${base64Data}`;
+    const payload = getEncoder().encode(protocolString);
 
     if (!payload) {
       throw new Error("Failed to create message payload");
@@ -762,7 +760,7 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
       const summary = await this.estimateTransaction({
         address: destinationAddress,
         amount: BigInt(0.2 * 100_000_000),
-        payload: payloadHex,
+        payload: payload,
         priorityFee: sendMessage.priorityFee,
       });
 
@@ -823,26 +821,10 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
     const isDirectSelfMessage =
       destinationAddress.toString() === this.receiveAddress?.toString();
 
-    const isMessageTransaction = isMessagePayload(transaction.payload);
-
-    const hasActiveConversation = this.monitoredAddresses.has(
-      destinationAddress.toString()
-    );
-
-    const isSelfMessage =
-      isMessageTransaction && (isDirectSelfMessage || hasActiveConversation);
-
-    console.log("Transaction type:", {
-      isDirectSelfMessage,
-      hasActiveConversation,
-      isMessageTransaction,
-      isSelfMessage,
-      payload: transaction.payload,
-    });
-
+    console.log(isDirectSelfMessage);
     // For regular transactions, always use the specified amount and destination
     // For self-messages, use empty outputs array to only use change output
-    const outputs = isSelfMessage
+    const outputs = isDirectSelfMessage
       ? []
       : [new PaymentOutput(destinationAddress, transaction.amount)];
 
@@ -898,14 +880,13 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
     }
 
     console.log("Using destination address:", transaction.address.toString());
-
+    console.error("1");
     const generateSummary = await this.estimateTransaction({
       address: new Address(transaction.address.toString()),
       amount: transaction.amount,
       payload: transaction.payload,
       priorityFee: transaction.priorityFee,
     });
-
     const estimatedFees = generateSummary.fees;
 
     const matureBalance = this.context.balance?.mature ?? 0n;
@@ -1279,7 +1260,6 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
     try {
       // Always send to our own address for self-send messages
       const destinationAddress = new Address(this.receiveAddress.toString());
-
       // Send to our own address
       const txId = await this.createTransaction(
         {

--- a/src/service/account-service.ts
+++ b/src/service/account-service.ts
@@ -392,80 +392,6 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
     return txId;
   }
 
-  private async createTransaction(
-    transaction: CreateTransactionArgs
-  ): Promise<TransactionId> {
-    this.assertReady();
-
-    if (!transaction.address) {
-      throw new Error("Transaction address is required");
-    }
-
-    if (transaction.amount === null || transaction.amount === undefined) {
-      throw new Error("Transaction amount is required");
-    }
-
-    console.log("=== CREATING TRANSACTION ===");
-    const primaryAddress = this.recv;
-    console.log(
-      "Creating transaction from primary address:",
-      primaryAddress.toString()
-    );
-    console.log(
-      "Change will go back to primary address:",
-      primaryAddress.toString()
-    );
-    console.log(`Destination: ${transaction.address.toString()}`);
-    console.log(
-      `Amount: ${Number(transaction.amount) / 100000000} KAS (${
-        transaction.amount
-      } sompi)`
-    );
-    console.log(`Payload length: ${transaction.payload.length / 2} bytes`);
-
-    const privateKeyGenerator = WalletStorageService.getPrivateKeyGenerator(
-      this.unlockedWallet,
-      this.pwd
-    );
-
-    if (!privateKeyGenerator) {
-      throw new Error("Failed to generate private key");
-    }
-
-    try {
-      // Use our optimized generator creation method
-      const generator = TransactionGeneratorService.createForTransaction({
-        context: this.ctx,
-        networkId: this.networkId,
-        receiveAddress: this.recv,
-        destinationAddress: transaction.address,
-        amount: transaction.amount,
-        payload: transaction.payload,
-        priorityFee: transaction.priorityFee,
-      });
-
-      console.log("Generating transaction...");
-      const pendingTransaction: PendingTransaction | null =
-        await generator.next();
-
-      if (!pendingTransaction) {
-        throw new Error("Failed to generate transaction");
-      }
-
-      if ((await generator.next()) !== null) {
-        throw new Error("Unexpected multiple transaction generation");
-      }
-
-      return this.signAndSubmitTransaction(
-        pendingTransaction,
-        privateKeyGenerator
-      );
-    } catch (error) {
-      console.error("Error creating transaction:", error);
-      throw error;
-    }
-  }
-
   private updateMonitoredConversations() {
     try {
       const messagingStore = useMessagingStore.getState();
@@ -761,6 +687,80 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
     }
   }
 
+  public async createTransaction(
+    transaction: CreateTransactionArgs
+  ): Promise<TransactionId> {
+    this.assertReady();
+
+    if (!transaction.address) {
+      throw new Error("Transaction address is required");
+    }
+
+    if (transaction.amount === null || transaction.amount === undefined) {
+      throw new Error("Transaction amount is required");
+    }
+
+    console.log("=== CREATING TRANSACTION ===");
+    const primaryAddress = this.recv;
+    console.log(
+      "Creating transaction from primary address:",
+      primaryAddress.toString()
+    );
+    console.log(
+      "Change will go back to primary address:",
+      primaryAddress.toString()
+    );
+    console.log(`Destination: ${transaction.address.toString()}`);
+    console.log(
+      `Amount: ${Number(transaction.amount) / 100000000} KAS (${
+        transaction.amount
+      } sompi)`
+    );
+    console.log(`Payload length: ${transaction.payload.length / 2} bytes`);
+
+    const privateKeyGenerator = WalletStorageService.getPrivateKeyGenerator(
+      this.unlockedWallet,
+      this.pwd
+    );
+
+    if (!privateKeyGenerator) {
+      throw new Error("Failed to generate private key");
+    }
+
+    try {
+      // Use our optimized generator creation method
+      const generator = TransactionGeneratorService.createForTransaction({
+        context: this.ctx,
+        networkId: this.networkId,
+        receiveAddress: this.recv,
+        destinationAddress: transaction.address,
+        amount: transaction.amount,
+        payload: transaction.payload,
+        priorityFee: transaction.priorityFee,
+      });
+
+      console.log("Generating transaction...");
+      const pendingTransaction: PendingTransaction | null =
+        await generator.next();
+
+      if (!pendingTransaction) {
+        throw new Error("Failed to generate transaction");
+      }
+
+      if ((await generator.next()) !== null) {
+        throw new Error("Unexpected multiple transaction generation");
+      }
+
+      return this.signAndSubmitTransaction(
+        pendingTransaction,
+        privateKeyGenerator
+      );
+    } catch (error) {
+      console.error("Error creating transaction:", error);
+      throw error;
+    }
+  }
+
   public async createPaymentWithMessage(
     paymentTransaction: CreatePaymentWithMessageArgs
   ): Promise<TransactionId> {
@@ -1000,20 +1000,21 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
     );
     const addressString = destinationAddress.toString();
     // Message needs to be encrypted
-
     const encryptedMessage = encrypt_message(
       addressString,
       sendMessage.message
     );
+
     if (!encryptedMessage) {
       throw new Error("Failed to encrypt message");
     }
-    const bytesData = hexToBytes(encryptedMessage.to_hex());
-    const base64Data = btoa(String.fromCharCode(...bytesData));
 
-    // Build the full protocol string with all components to match sendMessageWithContext
-    const protocolString = `ciph_msg:1:comm:${PLACEHOLDER_ALIAS}:${base64Data}`;
-    const payload = getEncoder().encode(protocolString);
+    const payload = `${PROTOCOL.prefix.string}${PROTOCOL.headers.COMM.string}${PLACEHOLDER_ALIAS}:${encryptedMessage.to_hex()}`;
+
+    const payloadHex = payload
+      .split("")
+      .map((c) => c.charCodeAt(0).toString(16).padStart(2, "0"))
+      .join("");
 
     if (!payload) {
       throw new Error("Failed to create message payload");
@@ -1026,7 +1027,7 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
         receiveAddress: this.recv,
         destinationAddress: destinationAddress,
         amount: BigInt(0.2 * 100_000_000),
-        payload: payload,
+        payload: payloadHex,
         priorityFee: sendMessage.priorityFee,
       }).estimate();
     } catch (error) {

--- a/src/service/account-service.ts
+++ b/src/service/account-service.ts
@@ -7,7 +7,6 @@ import {
   ITransaction,
   PendingTransaction,
   GeneratorSummary,
-  FeeSource,
   sompiToKaspaString,
   kaspaToSompi,
   ITransactionOutput,
@@ -27,11 +26,7 @@ import {
   PriorityFeeConfig,
 } from "../types/all";
 import { UnlockedWallet } from "../types/wallet.type";
-import {
-  ExplorerTransaction,
-  TransactionId,
-  getTransactionId,
-} from "../types/transactions";
+import { TransactionId, getTransactionId } from "../types/transactions";
 import { useMessagingStore } from "../store/messaging.store";
 import { useDBStore } from "../store/db.store";
 import { PROTOCOL, toHex } from "../config/protocol";
@@ -493,6 +488,7 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
     }
   }
 
+  // note: account service should not be responsible for handling block added logic
   private async processBlockEvent(event: BlockAddedData) {
     try {
       const blockTime =
@@ -507,6 +503,9 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
         }
       });
 
+      // note: this should be optimized, account service shouldn't be the owner of that
+      // it shouldn't be needed to refresh computation here if the owner of this would be the
+      // maintainer of the shared state
       this.updateMonitoredConversations();
 
       for (const tx of transactions) {
@@ -539,293 +538,161 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
     }
   }
 
-  /**
-   * Helper function to handle SEC1 format compatibility
-   * for pre-encrypted messages
-   */
-  private adjustForSEC1Format(encryptedHex: string): string {
-    // Check if the key starts with 02 or 03 (compressed SEC1 format)
-    const keyStart = encryptedHex.substring(24, 26);
-    if (keyStart !== "02" && keyStart !== "03") {
-      return encryptedHex; // Not a SEC1 key, return unchanged
-    }
-
-    console.log("Detected SEC1 compressed key format in pre-encrypted message");
-
-    // Extract components
-    const nonce = encryptedHex.substring(0, 24);
-    const ephemeralPublicKey = encryptedHex.substring(24, 24 + 66);
-    const ciphertext = encryptedHex.substring(24 + 66);
-
-    // Extract the X coordinate (without the 02/03 prefix)
-    const publicKeyWithoutPrefix = ephemeralPublicKey.substring(2);
-
-    // The public key should be exactly 32 bytes (64 hex chars)
-    // If it's shorter, pad it with zeros at the end
-    const paddedPublicKey = publicKeyWithoutPrefix.padEnd(64, "0");
-
-    // Create new hex with padded public key
-    const modifiedHex = nonce + paddedPublicKey + ciphertext;
-    console.log("Adjusted hex for SEC1 format compatibility");
-
-    return modifiedHex;
-  }
-
   private async processMessageTransaction(
-    tx: ITransaction | ExplorerTransaction,
+    tx: ITransaction,
     blockTime: number,
     maxRetries = 10
   ) {
-    if (!this.password) return;
+    const payload = tx.payload;
+    if (!payload.startsWith(PROTOCOL.prefix.hex)) {
+      return;
+    }
 
-    try {
-      const txId = getTransactionId(tx);
+    const txId = getTransactionId(tx);
 
-      if (!txId) {
-        console.warn("Transaction ID is missing in real-time processing");
-        return;
+    if (!txId) {
+      console.warn("Transaction ID is missing in real-time processing");
+      return;
+    }
+
+    if (
+      await useDBStore.getState().repositories.doesKasiaEventExistsById(txId)
+    ) {
+      console.log(`Transaction ${txId} already processed`);
+      return;
+    }
+
+    // note: ideally we wouldn't need to compute the address once more
+    // if this is needed, it means the loading strategy is wrong
+    // and should queue added block events before ingesting them
+    const walletAddress = this.unlockedWallet.publicKeyGenerator.receiveAddress(
+      this.networkId,
+      0
+    );
+    const stringWalletAddress = walletAddress.toString();
+
+    if (DecryptionCache.hasFailed(stringWalletAddress, txId)) {
+      if (process.env.NODE_ENV === "development") {
+        console.debug(`Real-time: Skipping known failed decryption: ${txId}`);
       }
+      return;
+    }
 
-      if (
-        await useDBStore.getState().repositories.doesKasiaEventExistsById(txId)
-      ) {
-        console.log(`Transaction ${txId} already processed`);
-        return;
-      }
+    // Get sender address from transaction inputs
+    let senderAddress = null;
+    if (tx.inputs && tx.inputs.length > 0) {
+      const input = tx.inputs[0];
+      const prevTxId = input.previousOutpoint?.transactionId;
+      const prevOutputIndex = input.previousOutpoint?.index;
 
-      const walletAddress =
-        this.unlockedWallet.publicKeyGenerator.receiveAddress(
-          this.networkId,
-          0
-        );
-      const stringWalletAddress = walletAddress.toString();
-
-      // 🚀 OPTIMIZATION: Skip if we know this transaction failed decryption before
-      if (DecryptionCache.hasFailed(stringWalletAddress, txId)) {
-        if (process.env.NODE_ENV === "development") {
-          console.debug(`Real-time: Skipping known failed decryption: ${txId}`);
+      if (prevTxId && typeof prevOutputIndex === "number") {
+        try {
+          const prevTx = await this._fetchTransactionDetails(
+            // this returns an explorer transaction
+            prevTxId,
+            maxRetries
+          );
+          if (prevTx?.outputs && prevTx.outputs[prevOutputIndex]) {
+            const output = prevTx.outputs[prevOutputIndex];
+            console.log("resolved sender address from prevTx: ", output);
+            senderAddress = output.script_public_key_address;
+          }
+        } catch (error) {
+          console.error("Error getting sender address:", error);
         }
-        return;
       }
-      // Get sender address from transaction inputs
-      let senderAddress = null;
-      if (isITransaction(tx) && tx.inputs && tx.inputs.length > 0) {
-        const input = tx.inputs[0];
-        const prevTxId = input.previousOutpoint?.transactionId;
-        const prevOutputIndex = input.previousOutpoint?.index;
+    }
 
-        if (prevTxId && typeof prevOutputIndex === "number") {
+    // @TODO(indexer): shouldn't use this fallback, can lead to fake id.
+    // If we still don't have a sender address, use the change output address
+    if (!senderAddress && tx.outputs && tx.outputs.length > 1) {
+      senderAddress = tx.outputs[1].verboseData?.scriptPublicKeyAddress;
+    }
+
+    // Get the recipient address from the outputs
+    let recipientAddress = null;
+    if (tx.outputs && tx.outputs.length > 0) {
+      recipientAddress = tx.outputs[0].verboseData?.scriptPublicKeyAddress;
+    }
+
+    // If we still don't have a sender address, try to fetch it from the previous transaction
+    if (!senderAddress && tx.inputs && tx.inputs.length > 0) {
+      // Try all inputs to find a valid sender address
+      for (let i = 0; i < tx.inputs.length; i++) {
+        const input = tx.inputs[i];
+        // previous_outpoint_hash
+        const prevTxId = input.previousOutpoint.transactionId;
+        const prevOutputIndex = input.previousOutpoint.index;
+
+        if (prevTxId) {
           try {
             const prevTx = await this._fetchTransactionDetails(
-              // this returns an explorer transaction
               prevTxId,
               maxRetries
             );
             if (prevTx?.outputs && prevTx.outputs[prevOutputIndex]) {
               const output = prevTx.outputs[prevOutputIndex];
-              console.log("resolved sender address from prevTx: ", output);
               senderAddress = output.script_public_key_address;
+              break;
             }
           } catch (error) {
-            console.error("Error getting sender address:", error);
-          }
-        }
-      } else if (
-        isExplorerTransaction(tx) &&
-        tx.inputs &&
-        tx.inputs.length > 0
-      ) {
-        senderAddress = tx.inputs[0].previous_outpoint_address;
-      }
-
-      // If we still don't have a sender address, use the change output address
-      if (!senderAddress && tx.outputs && tx.outputs.length > 1) {
-        if (isITransaction(tx)) {
-          senderAddress = tx.outputs[1].verboseData?.scriptPublicKeyAddress;
-        } else {
-          senderAddress = tx.outputs[1].script_public_key_address;
-        }
-      }
-
-      // Get the recipient address from the outputs
-      let recipientAddress = null;
-      if (tx.outputs && tx.outputs.length > 0) {
-        if (isITransaction(tx)) {
-          recipientAddress = tx.outputs[0].verboseData?.scriptPublicKeyAddress;
-        } else {
-          recipientAddress = tx.outputs[0].script_public_key_address;
-        }
-      }
-
-      // If we still don't have a sender address, try to fetch it from the previous transaction
-      if (
-        !senderAddress &&
-        isExplorerTransaction(tx) &&
-        tx.inputs &&
-        tx.inputs.length > 0
-      ) {
-        // Try all inputs to find a valid sender address
-        for (let i = 0; i < tx.inputs.length; i++) {
-          const input = tx.inputs[i];
-          // previous_outpoint_hash
-          const prevTxId = input.previous_outpoint_hash;
-          const prevOutputIndex = parseInt(input.previous_outpoint_index);
-
-          if (prevTxId && !isNaN(prevOutputIndex)) {
-            try {
-              const prevTx = await this._fetchTransactionDetails(
-                prevTxId,
-                maxRetries
-              );
-              if (prevTx?.outputs && prevTx.outputs[prevOutputIndex]) {
-                const output = prevTx.outputs[prevOutputIndex];
-                senderAddress = output.script_public_key_address;
-                break;
-              }
-            } catch (error) {
-              console.error(
-                "Error getting sender address from previous transaction:",
-                error
-              );
-            }
+            console.error(
+              "Error getting sender address from previous transaction:",
+              error
+            );
           }
         }
       }
+    }
+    const parsed = parseKaspaMessagePayload(tx.payload);
 
-      // Process the message
-      const payload = getTransactionPayload(tx);
-      if (!payload.startsWith(PROTOCOL.prefix.hex)) {
-        return;
-      }
+    const messageType = parsed.type;
+    const targetAlias = parsed.alias;
 
-      const parsed = parseKaspaMessagePayload(tx.payload);
-      let messageType = parsed.type;
-      const targetAlias = parsed.alias;
+    // @TODO: check how to do hex manipulation properly, currently parsed.encryptedHex is a hex
+    // if we want to handle base64, it would need to find a way to do from/to hex properly in JS
+    // from my tests, it seems that the utils alters the hex
+    const hexEncryptedPayload = tryParseBase64AsHexToHex(parsed.encryptedHex);
 
-      const hexEncryptedPayload = tryBase64ToHex(parsed.encryptedHex);
+    const encryptedHex = hexEncryptedPayload;
+    const isHandshake = parsed.type === PROTOCOL.headers.HANDSHAKE.type;
 
-      const encryptedHex = hexEncryptedPayload;
-      let isHandshake = parsed.type === PROTOCOL.headers.HANDSHAKE.type;
+    const isMonitoredAddress =
+      (senderAddress && this.monitoredAddresses.has(senderAddress)) ||
+      (recipientAddress && this.monitoredAddresses.has(recipientAddress));
+    const isCommForUs =
+      messageType === PROTOCOL.headers.COMM.type &&
+      targetAlias &&
+      this.monitoredConversations.has(targetAlias);
 
-      const isMonitoredAddress =
-        (senderAddress && this.monitoredAddresses.has(senderAddress)) ||
-        (recipientAddress && this.monitoredAddresses.has(recipientAddress));
-      const isCommForUs =
-        messageType === PROTOCOL.headers.COMM.type &&
-        targetAlias &&
-        this.monitoredConversations.has(targetAlias);
+    // For payments, check if the sender address is one we're monitoring
+    // (i.e., we have a conversation with them OR they sent us a payment)
+    const isPaymentForUs =
+      messageType === PROTOCOL.headers.PAYMENT.type &&
+      (isMonitoredAddress ||
+        recipientAddress === this.receiveAddress?.toString());
 
-      // For payments, check if the sender address is one we're monitoring
-      // (i.e., we have a conversation with them OR they sent us a payment)
-      const isPaymentForUs =
-        messageType === PROTOCOL.headers.PAYMENT.type &&
-        (isMonitoredAddress ||
-          recipientAddress === this.receiveAddress?.toString());
+    try {
+      // note: same remark as earlier in the flow
+      // here we should need to re-generate the key because the context should already
+      // be unlocked, unless there is a logical error in the general loading strategy
+      const privateKeyGenerator = WalletStorageService.getPrivateKeyGenerator(
+        this.unlockedWallet,
+        this.pwd!
+      );
+
+      let decryptionSuccess = false;
 
       try {
-        const privateKeyGenerator = WalletStorageService.getPrivateKeyGenerator(
-          this.unlockedWallet,
-          this.pwd
+        const privateKey = privateKeyGenerator.receiveKey(0);
+
+        const decryptedContent = decrypt_message(
+          new EncryptedMessage(encryptedHex),
+          new PrivateKey(privateKey.toString())
         );
 
-        let decryptedContent = "";
-        let decryptionSuccess = false;
+        decryptionSuccess = true;
 
-        try {
-          const privateKey = privateKeyGenerator.receiveKey(0);
-          const txId = getTransactionId(tx);
-          if (!txId) {
-            throw new Error("Transaction ID is missing");
-          }
-          const result = await CipherHelper.tryDecrypt(
-            encryptedHex,
-            privateKey.toString(),
-            txId
-          );
-          decryptedContent = result;
-          decryptionSuccess = true;
-
-          if (
-            decryptedContent.includes(
-              `"type":"${PROTOCOL.headers.HANDSHAKE.type}"`
-            )
-          ) {
-            messageType = PROTOCOL.headers.HANDSHAKE.type;
-            isHandshake = true;
-            try {
-              // extract the JSON part
-              let jsonContent = decryptedContent;
-              if (
-                decryptedContent.includes(
-                  `${PROTOCOL.prefix.string}${PROTOCOL.headers.HANDSHAKE.string}`
-                )
-              ) {
-                jsonContent = decryptedContent.split(
-                  `${PROTOCOL.prefix.string}${PROTOCOL.headers.HANDSHAKE.string}`
-                )[1];
-              }
-              const handshakeData = JSON.parse(jsonContent);
-              if (handshakeData.isResponse) {
-                this.updateMonitoredConversations();
-              }
-            } catch (error) {
-              console.error("Error parsing handshake data:", error);
-            }
-          }
-        } catch (error) {
-          if (process.env.NODE_ENV === "development") {
-            console.debug(`Failed to decrypt with receive key:`, error);
-          }
-        }
-        if (!decryptionSuccess) {
-          try {
-            const privateKey = privateKeyGenerator.changeKey(0);
-            const txId = getTransactionId(tx);
-            if (!txId) {
-              throw new Error("Transaction ID is missing");
-            }
-            const result = await CipherHelper.tryDecrypt(
-              encryptedHex,
-              privateKey.toString(),
-              txId
-            );
-            decryptedContent = result;
-            decryptionSuccess = true;
-
-            if (
-              decryptedContent.includes(
-                `"type":"${PROTOCOL.headers.HANDSHAKE.type}"`
-              )
-            ) {
-              messageType = PROTOCOL.headers.HANDSHAKE.type;
-              isHandshake = true;
-              try {
-                // extract the JSON part
-                let jsonContent = decryptedContent;
-                if (
-                  decryptedContent.includes(
-                    `${PROTOCOL.prefix.string}${PROTOCOL.headers.HANDSHAKE.string}`
-                  )
-                ) {
-                  jsonContent = decryptedContent.split(
-                    `${PROTOCOL.prefix.string}${PROTOCOL.headers.HANDSHAKE.string}`
-                  )[1];
-                }
-                const handshakeData = JSON.parse(jsonContent);
-                if (handshakeData.isResponse) {
-                  this.updateMonitoredConversations();
-                }
-              } catch (error) {
-                console.error("Error parsing handshake data:", error);
-              }
-            }
-          } catch (error) {
-            if (process.env.NODE_ENV === "development") {
-              console.debug(`Failed to decrypt with change key:`, error);
-            }
-          }
-        }
-        // 🚀 OPTIMIZATION: Mark decryption result in cache
         if (decryptionSuccess) {
           DecryptionCache.markSuccess(stringWalletAddress, txId);
           if (process.env.NODE_ENV === "development") {
@@ -846,6 +713,22 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
           decryptionSuccess &&
           (isHandshake || isMonitoredAddress || isCommForUs || isPaymentForUs)
         ) {
+          // this hack is necessary because we have inconsistencies between data parsed at historical level
+          // , at live level (here is live level), and when client is the creator of the event
+          // so be "re-build" it like the other places, ideally this shouldn't be necessary
+          let hackedContent = decryptedContent;
+
+          if (parsed.type === "handshake") {
+            // handhshake payload is expected to be utf-8 encoded
+            hackedContent = `${PROTOCOL.prefix.string}${PROTOCOL.headers.HANDSHAKE.string}${decryptedContent}`;
+          } else if (parsed.type === "message") {
+            // message payload is expected to be hex encoded
+            hackedContent = `${PROTOCOL.prefix.hex}${PROTOCOL.headers.COMM.hex}${toHex(parsed.alias ?? "UNKNOWN")}:${decryptedContent}`;
+          } else if (parsed.type === "payment") {
+            // payment payload is expected to be hex encoded
+            hackedContent = `${PROTOCOL.prefix.hex}${PROTOCOL.headers.PAYMENT.hex}${decryptedContent}`;
+          }
+
           const kasiaTransaction: KasiaTransaction = {
             transactionId: txId,
             senderAddress: senderAddress || "Unknown",
@@ -853,11 +736,8 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
             createdAt: new Date(blockTime),
             // @TODO(indexdb): how to get fees?
             fee: 0,
-            content: decryptedContent,
-            amount:
-              Number(
-                isITransaction(tx) ? tx.outputs[0].value : tx.outputs[0].amount
-              ) / 100000000,
+            content: hackedContent,
+            amount: Number(tx.outputs[0].value) / 100000000,
             payload: tx.payload,
           };
 
@@ -869,12 +749,6 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
           if (messagingStore) {
             await messagingStore.storeKasiaTransactions([kasiaTransaction]);
           }
-
-          if (isHandshake) {
-            this.updateMonitoredConversations();
-          }
-
-          this.emit("messageReceived", kasiaTransaction);
         }
       } catch (error) {
         console.error("Error processing message:", error);
@@ -1165,327 +1039,6 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
     this.assertReady();
     return this.ctx.getMatureRange(0, this.ctx.matureLength);
   }
-  //=== Staging below
-  private isKasiaTransaction(tx: ITransaction | ExplorerTransaction): boolean {
-    return tx?.payload?.startsWith(PROTOCOL.prefix.hex) ?? false;
-  }
-
-  private async processMessageTransaction(
-    tx: ITransaction | ExplorerTransaction,
-    blockTime: number,
-    maxRetries = 10
-  ) {
-    if (!this.password) return;
-
-    try {
-      const txId = getTransactionId(tx);
-
-      if (!txId) {
-        console.warn("Transaction ID is missing in real-time processing");
-        return;
-      }
-
-      if (
-        await useDBStore.getState().repositories.doesKasiaEventExistsById(txId)
-      ) {
-        console.log(`Transaction ${txId} already processed`);
-        return;
-      }
-
-      const walletAddress =
-        this.unlockedWallet.publicKeyGenerator.receiveAddress(
-          this.networkId,
-          0
-        );
-      const stringWalletAddress = walletAddress.toString();
-
-      // 🚀 OPTIMIZATION: Skip if we know this transaction failed decryption before
-      if (DecryptionCache.hasFailed(stringWalletAddress, txId)) {
-        if (process.env.NODE_ENV === "development") {
-          console.debug(`Real-time: Skipping known failed decryption: ${txId}`);
-        }
-        return;
-      }
-      // Get sender address from transaction inputs
-      let senderAddress = null;
-      if (isITransaction(tx) && tx.inputs && tx.inputs.length > 0) {
-        const input = tx.inputs[0];
-        const prevTxId = input.previousOutpoint?.transactionId;
-        const prevOutputIndex = input.previousOutpoint?.index;
-
-        if (prevTxId && typeof prevOutputIndex === "number") {
-          try {
-            const prevTx = await this._fetchTransactionDetails(
-              // this returns an explorer transaction
-              prevTxId,
-              maxRetries
-            );
-            if (prevTx?.outputs && prevTx.outputs[prevOutputIndex]) {
-              const output = prevTx.outputs[prevOutputIndex];
-              console.log("resolved sender address from prevTx: ", output);
-              senderAddress = output.script_public_key_address;
-            }
-          } catch (error) {
-            console.error("Error getting sender address:", error);
-          }
-        }
-      } else if (
-        isExplorerTransaction(tx) &&
-        tx.inputs &&
-        tx.inputs.length > 0
-      ) {
-        senderAddress = tx.inputs[0].previous_outpoint_address;
-      }
-
-      // If we still don't have a sender address, use the change output address
-      if (!senderAddress && tx.outputs && tx.outputs.length > 1) {
-        if (isITransaction(tx)) {
-          senderAddress = tx.outputs[1].verboseData?.scriptPublicKeyAddress;
-        } else {
-          senderAddress = tx.outputs[1].script_public_key_address;
-        }
-      }
-
-      // Get the recipient address from the outputs
-      let recipientAddress = null;
-      if (tx.outputs && tx.outputs.length > 0) {
-        if (isITransaction(tx)) {
-          recipientAddress = tx.outputs[0].verboseData?.scriptPublicKeyAddress;
-        } else {
-          recipientAddress = tx.outputs[0].script_public_key_address;
-        }
-      }
-
-      // If we still don't have a sender address, try to fetch it from the previous transaction
-      if (
-        !senderAddress &&
-        isExplorerTransaction(tx) &&
-        tx.inputs &&
-        tx.inputs.length > 0
-      ) {
-        // Try all inputs to find a valid sender address
-        for (let i = 0; i < tx.inputs.length; i++) {
-          const input = tx.inputs[i];
-          // previous_outpoint_hash
-          const prevTxId = input.previous_outpoint_hash;
-          const prevOutputIndex = parseInt(input.previous_outpoint_index);
-
-          if (prevTxId && !isNaN(prevOutputIndex)) {
-            try {
-              const prevTx = await this._fetchTransactionDetails(
-                prevTxId,
-                maxRetries
-              );
-              if (prevTx?.outputs && prevTx.outputs[prevOutputIndex]) {
-                const output = prevTx.outputs[prevOutputIndex];
-                senderAddress = output.script_public_key_address;
-                break;
-              }
-            } catch (error) {
-              console.error(
-                "Error getting sender address from previous transaction:",
-                error
-              );
-            }
-          }
-        }
-      }
-
-      // Process the message
-      const payload = getTransactionPayload(tx);
-      if (!payload.startsWith(PROTOCOL.prefix.hex)) {
-        return;
-      }
-
-      const parsed = parseKaspaMessagePayload(tx.payload);
-      let messageType = parsed.type;
-      const targetAlias = parsed.alias;
-
-      const hexEncryptedPayload = tryBase64ToHex(parsed.encryptedHex);
-
-      const encryptedHex = hexEncryptedPayload;
-      let isHandshake = parsed.type === PROTOCOL.headers.HANDSHAKE.type;
-
-      const isMonitoredAddress =
-        (senderAddress && this.monitoredAddresses.has(senderAddress)) ||
-        (recipientAddress && this.monitoredAddresses.has(recipientAddress));
-      const isCommForUs =
-        messageType === PROTOCOL.headers.COMM.type &&
-        targetAlias &&
-        this.monitoredConversations.has(targetAlias);
-
-      // For payments, check if the sender address is one we're monitoring
-      // (i.e., we have a conversation with them OR they sent us a payment)
-      const isPaymentForUs =
-        messageType === PROTOCOL.headers.PAYMENT.type &&
-        (isMonitoredAddress ||
-          recipientAddress === this.receiveAddress?.toString());
-
-      try {
-        const privateKeyGenerator = WalletStorageService.getPrivateKeyGenerator(
-          this.unlockedWallet,
-          this.pwd
-        );
-
-        let decryptedContent = "";
-        let decryptionSuccess = false;
-
-        try {
-          const privateKey = privateKeyGenerator.receiveKey(0);
-          const txId = getTransactionId(tx);
-          if (!txId) {
-            throw new Error("Transaction ID is missing");
-          }
-          const result = await CipherHelper.tryDecrypt(
-            encryptedHex,
-            privateKey.toString(),
-            txId
-          );
-          decryptedContent = result;
-          decryptionSuccess = true;
-
-          if (
-            decryptedContent.includes(
-              `"type":"${PROTOCOL.headers.HANDSHAKE.type}"`
-            )
-          ) {
-            messageType = PROTOCOL.headers.HANDSHAKE.type;
-            isHandshake = true;
-            try {
-              // extract the JSON part
-              let jsonContent = decryptedContent;
-              if (
-                decryptedContent.includes(
-                  `${PROTOCOL.prefix.string}${PROTOCOL.headers.HANDSHAKE.string}`
-                )
-              ) {
-                jsonContent = decryptedContent.split(
-                  `${PROTOCOL.prefix.string}${PROTOCOL.headers.HANDSHAKE.string}`
-                )[1];
-              }
-              const handshakeData = JSON.parse(jsonContent);
-              if (handshakeData.isResponse) {
-                this.updateMonitoredConversations();
-              }
-            } catch (error) {
-              console.error("Error parsing handshake data:", error);
-            }
-          }
-        } catch (error) {
-          if (process.env.NODE_ENV === "development") {
-            console.debug(`Failed to decrypt with receive key:`, error);
-          }
-        }
-        //=== Staging ABOVE
-        if (!decryptionSuccess) {
-          try {
-            const privateKey = privateKeyGenerator.changeKey(0);
-            const txId = getTransactionId(tx);
-            if (!txId) {
-              throw new Error("Transaction ID is missing");
-            }
-            const result = await CipherHelper.tryDecrypt(
-              encryptedHex,
-              privateKey.toString(),
-              txId
-            );
-            decryptedContent = result;
-            decryptionSuccess = true;
-
-            if (
-              decryptedContent.includes(
-                `"type":"${PROTOCOL.headers.HANDSHAKE.type}"`
-              )
-            ) {
-              messageType = PROTOCOL.headers.HANDSHAKE.type;
-              isHandshake = true;
-              try {
-                // extract the JSON part
-                let jsonContent = decryptedContent;
-                if (
-                  decryptedContent.includes(
-                    `${PROTOCOL.prefix.string}${PROTOCOL.headers.HANDSHAKE.string}`
-                  )
-                ) {
-                  jsonContent = decryptedContent.split(
-                    `${PROTOCOL.prefix.string}${PROTOCOL.headers.HANDSHAKE.string}`
-                  )[1];
-                }
-                const handshakeData = JSON.parse(jsonContent);
-                if (handshakeData.isResponse) {
-                  this.updateMonitoredConversations();
-                }
-              } catch (error) {
-                console.error("Error parsing handshake data:", error);
-              }
-            }
-          } catch (error) {
-            if (process.env.NODE_ENV === "development") {
-              console.debug(`Failed to decrypt with change key:`, error);
-            }
-          }
-        }
-        // 🚀 OPTIMIZATION: Mark decryption result in cache
-        if (decryptionSuccess) {
-          DecryptionCache.markSuccess(stringWalletAddress, txId);
-          if (process.env.NODE_ENV === "development") {
-            console.debug(
-              `Real-time: Successful decryption for ${txId} - removed from failed cache if present`
-            );
-          }
-        } else {
-          DecryptionCache.markFailed(stringWalletAddress, txId);
-          if (process.env.NODE_ENV === "development") {
-            console.debug(
-              `Real-time: Failed decryption for ${txId} - marked as failed in cache`
-            );
-          }
-        }
-
-        if (
-          decryptionSuccess &&
-          (isHandshake || isMonitoredAddress || isCommForUs || isPaymentForUs)
-        ) {
-          const kasiaTransaction: KasiaTransaction = {
-            transactionId: txId,
-            senderAddress: senderAddress || "Unknown",
-            recipientAddress: recipientAddress || "Unknown",
-            createdAt: new Date(blockTime),
-            // @TODO(indexdb): how to get fees?
-            fee: 0,
-            content: decryptedContent,
-            amount:
-              Number(
-                isITransaction(tx) ? tx.outputs[0].value : tx.outputs[0].amount
-              ) / 100000000,
-            payload: tx.payload,
-          };
-
-          console.log("kasiaTransaction from account service", {
-            ...kasiaTransaction,
-          });
-
-          const messagingStore = useMessagingStore.getState();
-          if (messagingStore) {
-            await messagingStore.storeKasiaTransactions([kasiaTransaction]);
-          }
-
-          if (isHandshake) {
-            this.updateMonitoredConversations();
-          }
-
-          this.emit("messageReceived", kasiaTransaction);
-        }
-      } catch (error) {
-        console.error("Error processing message:", error);
-      }
-    } catch (error) {
-      console.error(
-        `Error processing message transaction ${getTransactionId(tx)}:`,
-        error
-      );
-    }
-  }
 
   public async sendMessageWithContext(sendMessage: SendMessageWithContextArgs) {
     this.assertReady();
@@ -1558,78 +1111,6 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
     } catch (error) {
       console.error("Error sending message with context:", error);
       throw error;
-    }
-  }
-
-  private updateMonitoredConversations() {
-    try {
-      const messagingStore = useMessagingStore.getState();
-      const conversationManager = messagingStore?.conversationManager;
-
-      if (!conversationManager) return;
-
-      // Update our monitored conversations
-      this.monitoredConversations.clear();
-      this.monitoredAddresses.clear();
-      const conversations = conversationManager.getMonitoredConversations();
-
-      // Silently update monitored conversations
-      conversations.forEach((conv: { alias: string; address: string }) => {
-        this.monitoredConversations.add(conv.alias);
-        this.monitoredAddresses.set(conv.address, conv.alias);
-      });
-    } catch (error) {
-      console.error("Error updating monitored conversations:", error);
-    }
-  }
-
-  // note: account service should not be responsible for handling block added logic
-  private async processBlockEvent(event: BlockAddedData) {
-    try {
-      const blockTime =
-        Number(event?.data?.block?.header?.timestamp) || Date.now();
-      const transactions = event?.data?.block?.transactions || [];
-
-      // Process transactions silently
-      const txOutputsMap = new Map<string, ITransactionOutput[]>();
-      transactions.forEach((tx) => {
-        if (tx.outputs && tx.verboseData?.transactionId) {
-          txOutputsMap.set(tx.verboseData.transactionId, tx.outputs);
-        }
-      });
-
-      // note: this should be optimized, account service shouldn't be the owner of that
-      // it shouldn't be needed to refresh computation here if the owner of this would be the
-      // maintainer of the shared state
-      this.updateMonitoredConversations();
-
-      for (const tx of transactions) {
-        const txId = tx.verboseData?.transactionId;
-        if (!txId || this.processedMessageIds.has(txId)) continue;
-
-        if (this.isKasiaTransaction(tx)) {
-          console.log("found a kasia transaction", { tx });
-          // mark the txId as processed to avoid duplicate processing
-          this.processedMessageIds.add(txId);
-          if (this.processedMessageIds.size > this.MAX_PROCESSED_MESSAGES) {
-            const oldestId = this.processedMessageIds.values().next().value;
-
-            if (oldestId) {
-              this.processedMessageIds.delete(oldestId);
-            }
-          }
-
-          try {
-            await this.processMessageTransaction(tx, blockTime);
-          } catch (error) {
-            if (process.env.NODE_ENV === "development") {
-              console.debug("Error processing message transaction:", error);
-            }
-          }
-        }
-      }
-    } catch (error) {
-      console.error("Error processing block event:", error);
     }
   }
 }

--- a/src/service/account-service.ts
+++ b/src/service/account-service.ts
@@ -11,6 +11,7 @@ import {
   sompiToKaspaString,
   kaspaToSompi,
   ITransactionOutput,
+  PrivateKeyGenerator,
 } from "kaspa-wasm";
 import { KaspaClient } from "./kaspa-client";
 import {
@@ -341,6 +342,53 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
     return null;
   }
 
+  private validateTransactionFee(feeAmount: bigint): void {
+    if (feeAmount > MAX_TX_FEE) {
+      throw new Error(
+        `Fee cannot exceed ${Number(MAX_TX_FEE) / 100_000_000} KAS`
+      );
+    }
+  }
+
+  private async signAndSubmitTransaction(
+    pendingTransaction: PendingTransaction,
+    privateKeyGenerator: PrivateKeyGenerator
+  ): Promise<string> {
+    // Validate transaction fee (to make sure its not super high!) before proceeding
+    this.validateTransactionFee(pendingTransaction.feeAmount);
+
+    // Log the addresses that need signing
+    const addressesToSign = pendingTransaction.addresses();
+    console.log(
+      `Transaction requires signing ${addressesToSign.length} addresses:`
+    );
+    addressesToSign.forEach((addr, i) => {
+      console.log(`  Address ${i + 1}: ${addr.toString()}`);
+    });
+
+    // Always use receive key for all addresses since we only use primary address
+    const privateKeys = pendingTransaction.addresses().map(() => {
+      console.log("Using primary address key for signing");
+      const key = privateKeyGenerator.receiveKey(0);
+      if (!key) {
+        throw new Error("Failed to generate private key for signing");
+      }
+      return key;
+    });
+
+    // Sign the transaction
+    console.log("Signing transaction...");
+    pendingTransaction.sign(privateKeys);
+
+    // Submit the transaction
+    console.log("Submitting transaction to network...");
+    const txId: string = await pendingTransaction.submit(this.rpc);
+    console.log(`Transaction submitted with ID: ${txId}`);
+    console.log("========================");
+
+    return txId;
+  }
+
   private async createTransaction(
     transaction: CreateTransactionArgs
   ): Promise<TransactionId> {
@@ -405,42 +453,10 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
         throw new Error("Unexpected multiple transaction generation");
       }
 
-      if (pendingTransaction.feeAmount > MAX_TX_FEE) {
-        throw new Error(
-          `Fee cannot exceed ${Number(MAX_TX_FEE) / 100_000_000} KAS`
-        );
-      }
-
-      // Log the addresses that need signing
-      const addressesToSign = pendingTransaction.addresses();
-      console.log(
-        `Transaction requires signing ${addressesToSign.length} addresses:`
+      return this.signAndSubmitTransaction(
+        pendingTransaction,
+        privateKeyGenerator
       );
-      addressesToSign.forEach((addr, i) => {
-        console.log(`  Address ${i + 1}: ${addr.toString()}`);
-      });
-
-      // Always use receive key for all addresses since we only use primary address
-      const privateKeys = pendingTransaction.addresses().map(() => {
-        console.log("Using primary address key for signing");
-        const key = privateKeyGenerator.receiveKey(0);
-        if (!key) {
-          throw new Error("Failed to generate private key for signing");
-        }
-        return key;
-      });
-
-      // Sign the transaction
-      console.log("Signing transaction...");
-      pendingTransaction.sign(privateKeys);
-
-      // Submit the transaction
-      console.log("Submitting transaction to network...");
-      const txId: string = await pendingTransaction.submit(this.rpc);
-      console.log(`Transaction submitted with ID: ${txId}`);
-      console.log("========================");
-
-      return txId;
     } catch (error) {
       console.error("Error creating transaction:", error);
       throw error;
@@ -911,35 +927,11 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
         throw new Error("Unexpected multiple transaction generation");
       }
 
-      // Log the addresses that need signing
-      const addressesToSign = pendingTransaction.addresses();
-      console.log(
-        `Transaction requires signing ${addressesToSign.length} addresses:`
+      // Sign and send the transaction
+      return this.signAndSubmitTransaction(
+        pendingTransaction,
+        privateKeyGenerator
       );
-      addressesToSign.forEach((addr, i) => {
-        console.log(`  Address ${i + 1}: ${addr.toString()}`);
-      });
-
-      // Always use receive key for all addresses since we only use primary address
-      const privateKeys = pendingTransaction.addresses().map(() => {
-        const key = privateKeyGenerator.receiveKey(0);
-        if (!key) {
-          throw new Error("Failed to generate private key for signing");
-        }
-        return key;
-      });
-
-      // Sign the transaction
-      pendingTransaction.sign(privateKeys);
-
-      // Submit the transaction
-      console.log("Submitting transaction to network...");
-
-      const txId: string = await pendingTransaction.submit(this.rpc);
-
-      console.log(`Payment with message submitted with ID: ${txId}`);
-
-      return txId;
     } catch (error) {
       console.error("Error creating payment with message:", error);
       throw error;
@@ -989,30 +981,11 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
         throw new Error("Failed to generate transaction");
       }
 
-      // Log the addresses that need signing
-      const addressesToSign = pendingTransaction.addresses();
-
-      addressesToSign.forEach((addr, i) => {
-        console.log(`  Address ${i + 1}: ${addr.toString()}`);
-      });
-
-      // Always use receive key for all addresses since we only use primary address
-      const privateKeys = pendingTransaction.addresses().map(() => {
-        const key = privateKeyGenerator.receiveKey(0);
-        if (!key) {
-          throw new Error("Failed to generate private key for signing");
-        }
-        return key;
-      });
-
-      // Sign the transaction
-      pendingTransaction.sign(privateKeys);
-      // submit
-      const txId: string = await pendingTransaction.submit(this.rpc);
-
-      console.log(`Transaction submitted with ID: ${txId}`);
-
-      return txId;
+      // Sign and send the transaction
+      return this.signAndSubmitTransaction(
+        pendingTransaction,
+        privateKeyGenerator
+      );
     } catch (error) {
       console.error("Error creating transaction:", error);
       throw error;
@@ -1053,31 +1026,11 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
         throw new Error("Failed to generate transaction");
       }
 
-      // Log the addresses that need signing
-      const addressesToSign = pendingTransaction.addresses();
-
-      addressesToSign.forEach((addr, i) => {
-        console.log(`  Address ${i + 1}: ${addr.toString()}`);
-      });
-
-      // Always use receive key for all addresses since we only use primary address
-      const privateKeys = pendingTransaction.addresses().map(() => {
-        const key = privateKeyGenerator.receiveKey(0);
-        if (!key) {
-          throw new Error("Failed to generate private key for signing");
-        }
-        return key;
-      });
-
       // Sign the transaction
-      pendingTransaction.sign(privateKeys);
-
-      // Submit the transaction
-      const txId: string = await pendingTransaction.submit(this.rpc);
-
-      console.log(`Transaction submitted with ID: ${txId}`);
-
-      return txId;
+      return this.signAndSubmitTransaction(
+        pendingTransaction,
+        privateKeyGenerator
+      );
     } catch (error) {
       console.error("Error creating compound transaction:", error);
       throw error;

--- a/src/service/account-service.ts
+++ b/src/service/account-service.ts
@@ -42,7 +42,6 @@ import { parseKaspaMessagePayload } from "../utils/message-payload";
 import {
   hexToBytes,
   getEncoder,
-  isMessagePayload,
   tryParseBase64AsHexToHex,
 } from "../utils/payload-encoding";
 import { WalletStorageService } from "./wallet-storage-service";
@@ -875,46 +874,23 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
   private async _getGeneratorForPaymentWithMessage(
     transaction: CreatePaymentWithMessageArgs
   ) {
-    if (!this.isStarted) {
-      throw new Error("Account service is not started");
-    }
-
-    console.log("Using destination address:", transaction.address.toString());
-    console.error("1");
-    const generateSummary = await this.estimateTransaction({
-      address: new Address(transaction.address.toString()),
-      amount: transaction.amount,
-      payload: transaction.payload,
-      priorityFee: transaction.priorityFee,
-    });
-    const estimatedFees = generateSummary.fees;
-
     const matureBalance = this.context.balance?.mature ?? 0n;
 
-    const isFullBalance = transaction.amount + estimatedFees >= matureBalance;
+    // if sending full balance, use ReceiverPays
+    const isFullBalance = transaction.amount >= matureBalance;
 
-    console.log("is full balance?:", {
-      requestedAmount: transaction.amount.toString(),
-      matureBalance: this.context.balance?.mature.toString(),
-      isFullBalance,
-    });
-
-    // if thats the case, use destination as change address and ReceiverPays fees
     const changeAddress = isFullBalance
       ? new Address(transaction.address.toString())
       : this.receiveAddress!;
 
-    // use ReceiverPays for full balance to avoid insufficient funds
     const priorityFee = isFullBalance
-      ? {
-          amount: BigInt(0),
-          source: FeeSource.ReceiverPays,
-        }
+      ? { amount: BigInt(0), source: FeeSource.ReceiverPays }
       : transaction.priorityFee || {
           amount: BigInt(0),
           source: FeeSource.SenderPays,
         };
-
+    // once we add custom fees we might need to bring back a estimate generator,
+    // but we at least wont be calling estimatetransaction functio extenally
     return new Generator({
       changeAddress,
       entries: this.context,
@@ -945,16 +921,20 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
       ? new Address(transaction.address.toString())
       : this.receiveAddress!;
 
+    // for full balance, use ReceiverPays (no choice). For partial, use SenderPays
+    const priorityFee = isFullBalance
+      ? { amount: BigInt(0), source: FeeSource.ReceiverPays }
+      : transaction.priorityFee || {
+          amount: BigInt(0),
+          source: FeeSource.SenderPays,
+        };
+
     return new Generator({
       changeAddress,
       entries: this.context,
-      // priorityEntries: this.context.getMatureRange(0, this.context.matureLength),
       outputs: [new PaymentOutput(transaction.address, transaction.amount)],
       networkId: this.networkId,
-      priorityFee: transaction.priorityFee || {
-        amount: BigInt(0),
-        source: FeeSource.ReceiverPays,
-      },
+      priorityFee,
     });
   }
 

--- a/src/service/account-service.ts
+++ b/src/service/account-service.ts
@@ -578,7 +578,11 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
     // @TODO: check how to do hex manipulation properly, currently parsed.encryptedHex is a hex
     // if we want to handle base64, it would need to find a way to do from/to hex properly in JS
     // from my tests, it seems that the utils alters the hex
-    const hexEncryptedPayload = tryParseBase64AsHexToHex(parsed.encryptedHex);
+    // ONLY apply base64 parsing for comm (message) transactions, not for payments/handshakes
+    let hexEncryptedPayload = parsed.encryptedHex;
+    if (parsed.type === PROTOCOL.headers.COMM.type) {
+      hexEncryptedPayload = tryParseBase64AsHexToHex(parsed.encryptedHex);
+    }
 
     const encryptedHex = hexEncryptedPayload;
     const isHandshake = parsed.type === PROTOCOL.headers.HANDSHAKE.type;
@@ -651,8 +655,8 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
             // message payload is expected to be hex encoded
             hackedContent = `${PROTOCOL.prefix.hex}${PROTOCOL.headers.COMM.hex}${toHex(parsed.alias ?? "UNKNOWN")}:${decryptedContent}`;
           } else if (parsed.type === "payment") {
-            // payment payload is expected to be hex encoded
-            hackedContent = `${PROTOCOL.prefix.hex}${PROTOCOL.headers.PAYMENT.hex}${decryptedContent}`;
+            // payment payload should be the raw decrypted JSON content
+            hackedContent = decryptedContent;
           }
 
           const kasiaTransaction: KasiaTransaction = {

--- a/src/service/account-service.ts
+++ b/src/service/account-service.ts
@@ -647,6 +647,99 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
     }
   }
 
+  public async createCompoundTransaction() {
+    if (!this.isStarted || !this.rpcClient.rpc) {
+      throw new Error("Account service is not started");
+    }
+
+    if (!this.receiveAddress) {
+      throw new Error("Receive address not initialized");
+    }
+
+    if (!this.context) {
+      throw new Error("UTXO context not initialized");
+    }
+
+    // ensure password is available
+    this.ensurePasswordSet();
+
+    console.log("=== CREATING COMPOUND TRANSACTION ===");
+    console.log("Consolidating all UTXOs to:", this.receiveAddress.toString());
+
+    const privateKeyGenerator = WalletStorageService.getPrivateKeyGenerator(
+      this.unlockedWallet,
+      this.password!
+    );
+
+    if (!privateKeyGenerator) {
+      throw new Error("Failed to generate private key");
+    }
+
+    try {
+      // refresh the UTXO context to ensure we have the latest UTXO data
+      await this.context.clear();
+      await this.context.trackAddresses([this.receiveAddress!]);
+
+      // validate UTXO availability before creating transaction
+      console.log("Validating UTXO availability...");
+      const balance = this.context.balance;
+      if (!balance || balance.mature === 0n) {
+        throw new Error("No mature UTXOs available for compound transaction");
+      }
+
+      // Use our simple compound transaction generator
+      const generator = this._getGeneratorForCompoundTransaction();
+
+      console.log("Generating transaction...");
+      const pendingTransaction: PendingTransaction | null =
+        await generator.next();
+
+      if (!pendingTransaction) {
+        throw new Error("Failed to generate transaction");
+      }
+
+      // Log the addresses that need signing
+      const addressesToSign = pendingTransaction.addresses();
+      console.log(
+        `Transaction requires signing ${addressesToSign.length} addresses:`
+      );
+      addressesToSign.forEach((addr, i) => {
+        console.log(`  Address ${i + 1}: ${addr.toString()}`);
+      });
+
+      // Always use receive key for all addresses since we only use primary address
+      const privateKeys = pendingTransaction.addresses().map(() => {
+        console.log("Using primary address key for signing");
+        const key = privateKeyGenerator.receiveKey(0);
+        if (!key) {
+          throw new Error("Failed to generate private key for signing");
+        }
+        return key;
+      });
+
+      // Sign the transaction
+      console.log("Signing transaction...");
+      pendingTransaction.sign(privateKeys);
+
+      // Submit the transaction
+      console.log("Submitting transaction to network...");
+
+      const txId: string = await pendingTransaction.submit(this.rpcClient.rpc);
+
+      console.log(`Transaction submitted with ID: ${txId}`);
+      console.log("========================");
+
+      // wait for transaction to propagate, then refresh context
+      await new Promise((resolve) => setTimeout(resolve, 500));
+      this._emitBalanceUpdate();
+
+      return txId;
+    } catch (error) {
+      console.error("Error creating compound transaction:", error);
+      throw error;
+    }
+  }
+
   public async estimateTransaction(transaction: CreateTransactionArgs) {
     if (!this.isStarted) {
       throw new Error("Account service is not started");
@@ -903,6 +996,17 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
       networkId: this.networkId,
       priorityFee,
       payload: transaction.payload,
+    });
+  }
+
+  private _getGeneratorForCompoundTransaction() {
+    // compound transaction - sweep operation to consolidate UTXOs
+    // for compound tx, we pass undefined to outputs which means we dont need to specify priorty fee
+    return new Generator({
+      changeAddress: this.receiveAddress!,
+      entries: this.context,
+      outputs: undefined as unknown as PaymentOutput[],
+      networkId: this.networkId,
     });
   }
 

--- a/src/service/account-service.ts
+++ b/src/service/account-service.ts
@@ -275,10 +275,18 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
     try {
       // Stop the UTXO processor
       await this.processor.stop();
+      await this.context.clear();
+
+      // Unsubscribe from block events using the RpcClient method
+      if (this.rpcClient.rpc) {
+        await this.rpcClient.rpc.unsubscribeBlockAdded();
+      }
 
       // Clean up our local state
       this.isStarted = false;
-      console.log("Successfully cleaned up UTXO subscription and processor");
+      console.log(
+        "Successfully cleaned up UTXO subscription, processor and context"
+      );
     } catch (error) {
       console.error(
         "Failed to clean up UTXO subscription and processor:",

--- a/src/service/account-service.ts
+++ b/src/service/account-service.ts
@@ -1012,13 +1012,12 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
     if (!encryptedMessage) {
       throw new Error("Failed to encrypt message");
     }
+    const bytesData = hexToBytes(encryptedMessage.to_hex());
+    const base64Data = btoa(String.fromCharCode(...bytesData));
 
-    const payload = `${PROTOCOL.prefix.string}${PROTOCOL.headers.COMM.string}${PLACEHOLDER_ALIAS}:${encryptedMessage.to_hex()}`;
-
-    const payloadHex = payload
-      .split("")
-      .map((c) => c.charCodeAt(0).toString(16).padStart(2, "0"))
-      .join("");
+    // Build the full protocol string with all components to match sendMessageWithContext
+    const protocolString = `ciph_msg:1:comm:${PLACEHOLDER_ALIAS}:${base64Data}`;
+    const payload = getEncoder().encode(protocolString);
 
     if (!payload) {
       throw new Error("Failed to create message payload");
@@ -1031,7 +1030,7 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
         receiveAddress: this.recv,
         destinationAddress: destinationAddress,
         amount: BigInt(0.2 * 100_000_000),
-        payload: payloadHex,
+        payload: payload,
         priorityFee: sendMessage.priorityFee,
       }).estimate();
     } catch (error) {

--- a/src/service/account-service.ts
+++ b/src/service/account-service.ts
@@ -298,78 +298,8 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
     return this.password;
   }
 
-  async start() {
-    try {
-      // Get the receive address from the wallet
-      const initialReceiveAddress =
-        this.unlockedWallet.publicKeyGenerator.receiveAddress(
-          this.networkId,
-          0
-        );
-
-      // Ensure it has the proper network prefix
-      this.receiveAddress = new Address(
-        ensureAddressPrefix(initialReceiveAddress.toString(), this.networkId)
-      );
-
-      console.log(
-        "Using primary address for all operations:",
-        this.receiveAddress.toString()
-      );
-
-      // Set up event listeners
-      console.log("Setting up event listeners...");
-      this.processor.addEventListener("balance", async () => {
-        console.log("Balance event received");
-        this._emitBalanceUpdate();
-      });
-
-      // start the processor
-      console.log("Starting UTXO processor...");
-      await this.processor.start();
-
-      // Only track primary address
-      const addressesToTrack = [this.receiveAddress!];
-
-      // Now track addresses in UTXO processor
-      console.log("Starting address tracking for primary address...");
-      await this.context.trackAddresses(addressesToTrack);
-
-      // Set up block subscription with optimized message handling
-      console.log("Setting up block subscription...");
-      await this.rpcClient.subscribeToBlockAdded((event) => {
-        // Fire-and-forget; callback signature remains (event) => void
-        void this.processBlockEvent(event as unknown as BlockAddedData);
-      });
-      console.log("Successfully subscribed to block events");
-
-      this.isStarted = true;
-    } catch (error) {
-      console.error("Failed to start account service:", error);
-      throw error;
-    }
-  }
-
-  async stop() {
-    console.log("Stopping UTXO subscription and processor...");
-    try {
-      // Stop the UTXO processor
-      await this.processor.stop();
-
-      // Clean up our local state
-      this.isStarted = false;
-      console.log("Successfully cleaned up UTXO subscription and processor");
-    } catch (error) {
-      console.error(
-        "Failed to clean up UTXO subscription and processor:",
-        error
-      );
-    }
-  }
-
-  public async createTransaction(
-    transaction: CreateTransactionArgs,
-    password: string
+  private async createTransaction(
+    transaction: CreateTransactionArgs
   ): Promise<TransactionId> {
     this.assertReady();
 
@@ -401,7 +331,7 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
 
     const privateKeyGenerator = WalletStorageService.getPrivateKeyGenerator(
       this.unlockedWallet,
-      password
+      this.pwd
     );
 
     if (!privateKeyGenerator) {
@@ -471,6 +401,75 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
     } catch (error) {
       console.error("Error creating transaction:", error);
       throw error;
+    }
+  }
+
+  async start() {
+    try {
+      // Get the receive address from the wallet
+      const initialReceiveAddress =
+        this.unlockedWallet.publicKeyGenerator.receiveAddress(
+          this.networkId,
+          0
+        );
+
+      // Ensure it has the proper network prefix
+      this.receiveAddress = new Address(
+        ensureAddressPrefix(initialReceiveAddress.toString(), this.networkId)
+      );
+
+      console.log(
+        "Using primary address for all operations:",
+        this.receiveAddress.toString()
+      );
+
+      // Set up event listeners
+      console.log("Setting up event listeners...");
+      this.processor.addEventListener("balance", async () => {
+        console.log("Balance event received");
+        this._emitBalanceUpdate();
+      });
+
+      // start the processor
+      console.log("Starting UTXO processor...");
+      await this.processor.start();
+
+      // Only track primary address
+      const addressesToTrack = [this.receiveAddress!];
+
+      // Now track addresses in UTXO processor
+      console.log("Starting address tracking for primary address...");
+      await this.context.trackAddresses(addressesToTrack);
+
+      // Set up block subscription with optimized message handling
+      console.log("Setting up block subscription...");
+      await this.rpcClient.subscribeToBlockAdded((event) => {
+        // Fire-and-forget; callback signature remains (event) => void
+        void this.processBlockEvent(event as unknown as BlockAddedData);
+      });
+      console.log("Successfully subscribed to block events");
+
+      this.isStarted = true;
+    } catch (error) {
+      console.error("Failed to start account service:", error);
+      throw error;
+    }
+  }
+
+  async stop() {
+    console.log("Stopping UTXO subscription and processor...");
+    try {
+      // Stop the UTXO processor
+      await this.processor.stop();
+
+      // Clean up our local state
+      this.isStarted = false;
+      console.log("Successfully cleaned up UTXO subscription and processor");
+    } catch (error) {
+      console.error(
+        "Failed to clean up UTXO subscription and processor:",
+        error
+      );
     }
   }
 
@@ -747,15 +746,12 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
     }
 
     try {
-      const txId = await this.createTransaction(
-        {
-          address: destinationAddress,
-          amount: messageAmount,
-          payload: payload,
-          priorityFee: sendMessage.priorityFee,
-        },
-        sendMessage.password
-      );
+      const txId = await this.createTransaction({
+        address: destinationAddress,
+        amount: messageAmount,
+        payload: payload,
+        priorityFee: sendMessage.priorityFee,
+      });
 
       return txId;
     } catch (error) {
@@ -1148,15 +1144,12 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
       // Always send to our own address for self-send messages
       const destinationAddress = new Address(this.recv.toString());
       // Send to our own address
-      const txId = await this.createTransaction(
-        {
-          address: destinationAddress,
-          amount: minimumAmount,
-          payload: payload,
-          priorityFee: sendMessage.priorityFee,
-        },
-        sendMessage.password
-      );
+      const txId = await this.createTransaction({
+        address: destinationAddress,
+        amount: minimumAmount,
+        payload: payload,
+        priorityFee: sendMessage.priorityFee,
+      });
 
       return txId;
     } catch (error) {

--- a/src/service/account-service.ts
+++ b/src/service/account-service.ts
@@ -32,7 +32,6 @@ import {
   getTransactionId,
 } from "../types/transactions";
 import { useMessagingStore } from "../store/messaging.store";
-import { useWalletStore } from "../store/wallet.store";
 import { useDBStore } from "../store/db.store";
 import { PROTOCOL, toHex } from "../config/protocol";
 import { PLACEHOLDER_ALIAS } from "../config/constants";
@@ -45,6 +44,7 @@ import {
 import { WalletStorageService } from "./wallet-storage-service";
 import { TransactionGeneratorService } from "./transaction-generator";
 import { MAX_TX_FEE } from "../config/constants";
+import { ensureAddressPrefix } from "../utils/network";
 
 // strictly typed events
 type AccountServiceEvents = {
@@ -276,7 +276,9 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
         );
 
       // Ensure it has the proper network prefix
-      this.receiveAddress = this.ensureAddressPrefix(initialReceiveAddress);
+      this.receiveAddress = new Address(
+        ensureAddressPrefix(initialReceiveAddress.toString(), this.networkId)
+      );
 
       console.log(
         "Using primary address for all operations:",
@@ -703,7 +705,9 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
       throw new Error("Password is required");
     }
 
-    const destinationAddress = this.ensureAddressPrefix(sendMessage.toAddress);
+    const destinationAddress = new Address(
+      ensureAddressPrefix(sendMessage.toAddress.toString(), this.networkId)
+    );
     const addressString = destinationAddress.toString();
 
     // Check if the message is already encrypted (hex format)
@@ -758,7 +762,9 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
       throw new Error("Message is required");
     }
 
-    const destinationAddress = this.ensureAddressPrefix(sendMessage.toAddress);
+    const destinationAddress = new Address(
+      ensureAddressPrefix(sendMessage.toAddress.toString(), this.networkId)
+    );
     const addressString = destinationAddress.toString();
     // Message needs to be encrypted
 
@@ -802,31 +808,6 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
 
     return this.context.getMatureRange(0, this.context.matureLength);
   }
-
-  /**
-   * Helper method to ensure an address has the proper network prefix
-   */
-  private ensureAddressPrefix(address: Address): Address {
-    const addressString = address.toString();
-
-    // If address already has a prefix, return it unchanged
-    if (addressString.includes(":")) {
-      return address;
-    }
-
-    // Add appropriate prefix based on network
-    let prefixedAddressString = addressString;
-    if (this.networkId === "testnet-10" || this.networkId === "testnet-11") {
-      prefixedAddressString = `kaspatest:${addressString}`;
-    } else if (this.networkId === "mainnet") {
-      prefixedAddressString = `kaspa:${addressString}`;
-    } else if (this.networkId === "devnet") {
-      prefixedAddressString = `kaspadev:${addressString}`;
-    }
-
-    console.log(`Added prefix to address: ${prefixedAddressString}`);
-    return new Address(prefixedAddressString);
-  } // TODO Utility
 
   private isKasiaTransaction(tx: ITransaction | ExplorerTransaction): boolean {
     return tx?.payload?.startsWith(PROTOCOL.prefix.hex) ?? false;

--- a/src/service/account-service.ts
+++ b/src/service/account-service.ts
@@ -64,7 +64,6 @@ type AccountServiceEvents = {
 type SendMessageArgs = {
   toAddress: Address;
   message: string;
-  password: string;
   amount?: bigint; // Optional custom amount, defaults to 0.2 KAS
   priorityFee?: PriorityFeeConfig; // Add priority fee support
 };
@@ -78,7 +77,6 @@ type EstimateSendMessageFeesArgs = {
 type SendMessageWithContextArgs = {
   toAddress: Address;
   message: string;
-  password: string;
   theirAlias: string;
   priorityFee?: PriorityFeeConfig; // Add priority fee support
 };
@@ -154,13 +152,6 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
     }
     console.log("Setting password in AccountService");
     this.password = password;
-  }
-
-  // Add method to check if password is set
-  private ensurePasswordSet() {
-    if (!this.password) {
-      throw new Error("Password not set - cannot perform operation");
-    }
   }
 
   private _emitBalanceUpdate() {
@@ -248,23 +239,6 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
     }
     return null;
   }
-
-  // private validateTransactionPrerequisites() {
-  //   if (!this.isStarted || !this.rpcClient.rpc) {
-  //     throw new Error("Account service is not started");
-  //   }
-
-  //   if (!this.receiveAddress) {
-  //     throw new Error("Receive address not initialized");
-  //   }
-
-  //   if (!this.context) {
-  //     throw new Error("UTXO context not initialized");
-  //   }
-
-  //   // ensure password is available
-  //   this.ensurePasswordSet();
-  // }
 
   private assertReady(): asserts this is AccountService & {
     receiveAddress: Address;
@@ -435,10 +409,7 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
       await this.processor.start();
 
       // Only track primary address
-      const addressesToTrack = [this.receiveAddress!];
-
-      // Now track addresses in UTXO processor
-      console.log("Starting address tracking for primary address...");
+      const addressesToTrack = [this.receiveAddress];
       await this.context.trackAddresses(addressesToTrack);
 
       // Set up block subscription with optimized message handling
@@ -697,7 +668,7 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
   public async sendMessage(
     sendMessage: SendMessageArgs
   ): Promise<TransactionId> {
-    this.ensurePasswordSet();
+    this.assertReady();
     // Use custom amount if provided, otherwise default to 0.2 KAS
     const defaultAmount = kaspaToSompi("0.2");
     const messageAmount = sendMessage.amount || defaultAmount;
@@ -712,10 +683,6 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
 
     if (!sendMessage.message) {
       throw new Error("Message is required");
-    }
-
-    if (!sendMessage.password) {
-      throw new Error("Password is required");
     }
 
     const destinationAddress = new Address(
@@ -784,11 +751,12 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
       addressString,
       sendMessage.message
     );
-    const bytesData = hexToBytes(encryptedMessage.to_hex());
-    const base64Data = btoa(String.fromCharCode(...bytesData));
     if (!encryptedMessage) {
       throw new Error("Failed to encrypt message");
     }
+    const bytesData = hexToBytes(encryptedMessage.to_hex());
+    const base64Data = btoa(String.fromCharCode(...bytesData));
+
     // Build the full protocol string with all components to match sendMessageWithContext
     const protocolString = `ciph_msg:1:comm:${PLACEHOLDER_ALIAS}:${base64Data}`;
     const payload = getEncoder().encode(protocolString);
@@ -827,6 +795,8 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
     blockTime: number,
     maxRetries = 10
   ) {
+    if (!this.password) return;
+
     const payload = tx.payload;
     if (!payload.startsWith(PROTOCOL.prefix.hex)) {
       return;
@@ -908,7 +878,7 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
         const prevTxId = input.previousOutpoint.transactionId;
         const prevOutputIndex = input.previousOutpoint.index;
 
-        if (prevTxId) {
+            if (prevTxId) {
           try {
             const prevTx = await this._fetchTransactionDetails(
               prevTxId,
@@ -929,11 +899,11 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
       }
     }
 
-    try {
-      this.ensurePasswordSet();
-    } catch {
-      return;
-    }
+      // Process the message
+      const payload = getTransactionPayload(tx);
+      if (!payload.startsWith(PROTOCOL.prefix.hex)) {
+        return;
+      }
 
     const parsed = parseKaspaMessagePayload(tx.payload);
 
@@ -1095,10 +1065,6 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
 
     if (!sendMessage.message) {
       throw new Error("Message is required");
-    }
-
-    if (!sendMessage.password) {
-      throw new Error("Password is required");
     }
 
     if (!sendMessage.theirAlias) {

--- a/src/service/account-service.ts
+++ b/src/service/account-service.ts
@@ -249,6 +249,23 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
     return null;
   }
 
+  private validateTransactionPrerequisites() {
+    if (!this.isStarted || !this.rpcClient.rpc) {
+      throw new Error("Account service is not started");
+    }
+
+    if (!this.receiveAddress) {
+      throw new Error("Receive address not initialized");
+    }
+
+    if (!this.context) {
+      throw new Error("UTXO context not initialized");
+    }
+
+    // ensure password is available
+    this.ensurePasswordSet();
+  }
+
   async start() {
     try {
       // Get the receive address from the wallet
@@ -422,7 +439,7 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
 
       // Submit the transaction
       console.log("Submitting transaction to network...");
-      const txId: string = await pendingTransaction.submit(this.rpcClient.rpc);
+      const txId: string = await pendingTransaction.submit(this.rpcClient.rpc!);
       console.log(`Transaction submitted with ID: ${txId}`);
       console.log("========================");
 
@@ -434,16 +451,9 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
   }
 
   public async createPaymentWithMessage(
-    paymentTransaction: CreatePaymentWithMessageArgs,
-    password: string
+    paymentTransaction: CreatePaymentWithMessageArgs
   ): Promise<TransactionId> {
-    if (!this.isStarted || !this.rpcClient.rpc) {
-      throw new Error("Account service is not started");
-    }
-
-    if (!this.receiveAddress) {
-      throw new Error("Receive address not initialized");
-    }
+    this.validateTransactionPrerequisites();
 
     if (!paymentTransaction.address) {
       throw new Error("Transaction address is required");
@@ -455,7 +465,7 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
 
     const privateKeyGenerator = WalletStorageService.getPrivateKeyGenerator(
       this.unlockedWallet,
-      password
+      this.password!
     );
 
     if (!privateKeyGenerator) {
@@ -467,6 +477,8 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
     }
 
     try {
+      const matureBalance = this.context.balance?.mature ?? 0n;
+      const isFullBalance = matureBalance === paymentTransaction.amount;
       // Use a modified generator that sends to recipient but includes payload
       const generator = TransactionGeneratorService.createForPaymentOrWithdraw({
         context: this.context,
@@ -476,6 +488,7 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
         amount: paymentTransaction.amount,
         payload: paymentTransaction.payload,
         priorityFee: paymentTransaction.priorityFee,
+        isFullBalance,
       });
 
       const pendingTransaction: PendingTransaction | null =
@@ -513,7 +526,7 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
       // Submit the transaction
       console.log("Submitting transaction to network...");
 
-      const txId: string = await pendingTransaction.submit(this.rpcClient.rpc);
+      const txId: string = await pendingTransaction.submit(this.rpcClient.rpc!);
 
       console.log(`Payment with message submitted with ID: ${txId}`);
 
@@ -525,16 +538,9 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
   }
 
   public async createWithdrawTransaction(
-    withdrawTransaction: CreateWithdrawTransactionArgs,
-    password: string
+    withdrawTransaction: CreateWithdrawTransactionArgs
   ) {
-    if (!this.isStarted || !this.rpcClient.rpc) {
-      throw new Error("Account service is not started");
-    }
-
-    if (!this.receiveAddress) {
-      throw new Error("Receive address not initialized");
-    }
+    this.validateTransactionPrerequisites();
 
     if (!withdrawTransaction.address) {
       throw new Error("Transaction address is required");
@@ -546,7 +552,7 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
 
     const privateKeyGenerator = WalletStorageService.getPrivateKeyGenerator(
       this.unlockedWallet,
-      password
+      this.password!
     );
 
     if (!privateKeyGenerator) {
@@ -558,6 +564,8 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
     }
 
     try {
+      const matureBalance = this.context.balance?.mature ?? 0n;
+      const isFullBalance = matureBalance === withdrawTransaction.amount;
       // Use our optimized generator creation method
       const generator = TransactionGeneratorService.createForPaymentOrWithdraw({
         context: this.context,
@@ -566,6 +574,7 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
         destinationAddress: withdrawTransaction.address,
         amount: withdrawTransaction.amount,
         priorityFee: withdrawTransaction.priorityFee,
+        isFullBalance: isFullBalance,
       });
 
       const pendingTransaction: PendingTransaction | null =
@@ -594,7 +603,7 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
       // Sign the transaction
       pendingTransaction.sign(privateKeys);
       // submit
-      const txId: string = await pendingTransaction.submit(this.rpcClient.rpc);
+      const txId: string = await pendingTransaction.submit(this.rpcClient.rpc!);
 
       console.log(`Transaction submitted with ID: ${txId}`);
 
@@ -606,22 +615,9 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
   }
 
   public async createCompoundTransaction() {
-    if (!this.isStarted || !this.rpcClient.rpc) {
-      throw new Error("Account service is not started");
-    }
+    this.validateTransactionPrerequisites();
 
-    if (!this.receiveAddress) {
-      throw new Error("Receive address not initialized");
-    }
-
-    if (!this.context) {
-      throw new Error("UTXO context not initialized");
-    }
-
-    // ensure password is available
-    this.ensurePasswordSet();
-
-    console.log("Consolidating all UTXOs to:", this.receiveAddress.toString());
+    console.log("Consolidating all UTXOs to:", this.receiveAddress!.toString());
 
     const privateKeyGenerator = WalletStorageService.getPrivateKeyGenerator(
       this.unlockedWallet,
@@ -672,7 +668,7 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
       pendingTransaction.sign(privateKeys);
 
       // Submit the transaction
-      const txId: string = await pendingTransaction.submit(this.rpcClient.rpc);
+      const txId: string = await pendingTransaction.submit(this.rpcClient.rpc!);
 
       console.log(`Transaction submitted with ID: ${txId}`);
 

--- a/src/service/account-service.ts
+++ b/src/service/account-service.ts
@@ -705,22 +705,6 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
     }
   }
 
-  public async estimateTransaction(transaction: CreateTransactionArgs) {
-    if (!this.isStarted) {
-      throw new Error("Account service is not started");
-    }
-
-    return TransactionGeneratorService.createForTransaction({
-      context: this.context,
-      networkId: this.networkId,
-      receiveAddress: this.receiveAddress!,
-      destinationAddress: transaction.address,
-      amount: transaction.amount,
-      payload: transaction.payload,
-      priorityFee: transaction.priorityFee,
-    }).estimate();
-  }
-
   public async sendMessage(
     sendMessage: SendMessageArgs
   ): Promise<TransactionId> {
@@ -822,14 +806,15 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
     }
 
     try {
-      const summary = await this.estimateTransaction({
-        address: destinationAddress,
+      return TransactionGeneratorService.createForTransaction({
+        context: this.context,
+        networkId: this.networkId,
+        receiveAddress: this.receiveAddress!,
+        destinationAddress: destinationAddress,
         amount: BigInt(0.2 * 100_000_000),
         payload: payload,
         priorityFee: sendMessage.priorityFee,
-      });
-
-      return summary;
+      }).estimate();
     } catch (error) {
       console.error("Error estimating transaction fees:", error);
       throw error;

--- a/src/service/account-service.ts
+++ b/src/service/account-service.ts
@@ -538,6 +538,7 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
   }
 
   public async createWithdrawTransaction(
+    // remove the external below and follow payment or compound approacgh
     withdrawTransaction: CreateWithdrawTransactionArgs
   ) {
     this.validateTransactionPrerequisites();

--- a/src/service/account-service.ts
+++ b/src/service/account-service.ts
@@ -35,7 +35,10 @@ import { useMessagingStore } from "../store/messaging.store";
 import { useDBStore } from "../store/db.store";
 import { PROTOCOL, toHex } from "../config/protocol";
 import { PLACEHOLDER_ALIAS } from "../config/constants";
-import { parseKaspaMessagePayload } from "../utils/message-payload";
+import {
+  parseKaspaMessagePayload,
+  isKasiaTransaction,
+} from "../utils/message-payload";
 import {
   hexToBytes,
   getEncoder,
@@ -121,25 +124,6 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
   // Add password field
   private password: string | null = null;
 
-  private get rpc() {
-    if (!this.rpcClient.rpc) throw new Error("RPC client is not initialized");
-    return this.rpcClient.rpc;
-  }
-  private get recv(): Address {
-    if (!this.receiveAddress)
-      throw new Error("Receive address not initialized");
-    return this.receiveAddress;
-  }
-  private get ctx(): UtxoContext {
-    if (!this.context) throw new Error("UTXO context not initialized");
-    return this.context;
-  }
-  private get pwd(): string {
-    if (!this.password)
-      throw new Error("Password not set - cannot perform operation");
-    return this.password;
-  }
-
   constructor(
     private readonly rpcClient: KaspaClient,
     private readonly unlockedWallet: UnlockedWallet
@@ -162,6 +146,38 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
     if (unlockedWallet.password) {
       this.password = unlockedWallet.password;
     }
+  }
+
+  private get rpc() {
+    if (!this.rpcClient.rpc) throw new Error("RPC client is not initialized");
+    return this.rpcClient.rpc;
+  }
+  private get recv(): Address {
+    if (!this.receiveAddress)
+      throw new Error("Receive address not initialized");
+    return this.receiveAddress;
+  }
+  private get ctx(): UtxoContext {
+    if (!this.context) throw new Error("UTXO context not initialized");
+    return this.context;
+  }
+  private get pwd(): string {
+    if (!this.password)
+      throw new Error("Password not set - cannot perform operation");
+    return this.password;
+  }
+
+  private assertReady(): asserts this is AccountService & {
+    receiveAddress: Address;
+    context: UtxoContext;
+  } {
+    if (!this.isStarted || !this.rpcClient.rpc)
+      throw new Error("Account service is not started");
+    if (!this.receiveAddress)
+      throw new Error("Receive address not initialized");
+    if (!this.context) throw new Error("UTXO context not initialized");
+    if (!this.password)
+      throw new Error("Password not set - cannot perform operation");
   }
 
   private _emitBalanceUpdate() {
@@ -193,6 +209,81 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
       matureUtxoCount: matureUtxos.length,
       pendingUtxoCount: pendingUtxos.length,
     });
+  }
+
+  // Add method to set password
+  public setPassword(password: string) {
+    if (!password) {
+      throw new Error("Password cannot be empty");
+    }
+    console.log("Setting password in AccountService");
+    this.password = password;
+  }
+
+  async start() {
+    try {
+      // Get the receive address from the wallet
+      const initialReceiveAddress =
+        this.unlockedWallet.publicKeyGenerator.receiveAddress(
+          this.networkId,
+          0
+        );
+
+      // Ensure it has the proper network prefix
+      this.receiveAddress = new Address(
+        ensureAddressPrefix(initialReceiveAddress.toString(), this.networkId)
+      );
+
+      console.log(
+        "Using primary address for all operations:",
+        this.receiveAddress.toString()
+      );
+
+      // Set up event listeners
+      console.log("Setting up event listeners...");
+      this.processor.addEventListener("balance", async () => {
+        console.log("Balance event received");
+        this._emitBalanceUpdate();
+      });
+
+      // start the processor
+      console.log("Starting UTXO processor...");
+      await this.processor.start();
+
+      // Only track primary address
+      const addressesToTrack = [this.receiveAddress];
+      await this.context.trackAddresses(addressesToTrack);
+
+      // Set up block subscription with optimized message handling
+      console.log("Setting up block subscription...");
+      await this.rpcClient.subscribeToBlockAdded((event) => {
+        // Fire-and-forget; callback signature remains (event) => void
+        void this.processBlockEvent(event as unknown as BlockAddedData);
+      });
+      console.log("Successfully subscribed to block events");
+
+      this.isStarted = true;
+    } catch (error) {
+      console.error("Failed to start account service:", error);
+      throw error;
+    }
+  }
+
+  async stop() {
+    console.log("Stopping UTXO subscription and processor...");
+    try {
+      // Stop the UTXO processor
+      await this.processor.stop();
+
+      // Clean up our local state
+      this.isStarted = false;
+      console.log("Successfully cleaned up UTXO subscription and processor");
+    } catch (error) {
+      console.error(
+        "Failed to clean up UTXO subscription and processor:",
+        error
+      );
+    }
   }
 
   private async _fetchTransactionDetails(txId: string, maxRetries = 10) {
@@ -248,19 +339,6 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
       }
     }
     return null;
-  }
-
-  private assertReady(): asserts this is AccountService & {
-    receiveAddress: Address;
-    context: UtxoContext;
-  } {
-    if (!this.isStarted || !this.rpcClient.rpc)
-      throw new Error("Account service is not started");
-    if (!this.receiveAddress)
-      throw new Error("Receive address not initialized");
-    if (!this.context) throw new Error("UTXO context not initialized");
-    if (!this.password)
-      throw new Error("Password not set - cannot perform operation");
   }
 
   private async createTransaction(
@@ -369,79 +447,420 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
     }
   }
 
-  async start() {
+  private updateMonitoredConversations() {
     try {
-      // Get the receive address from the wallet
-      const initialReceiveAddress =
+      const messagingStore = useMessagingStore.getState();
+      const conversationManager = messagingStore?.conversationManager;
+
+      if (!conversationManager) return;
+
+      // Update our monitored conversations
+      this.monitoredConversations.clear();
+      this.monitoredAddresses.clear();
+      const conversations = conversationManager.getMonitoredConversations();
+
+      // Silently update monitored conversations
+      conversations.forEach((conv: { alias: string; address: string }) => {
+        this.monitoredConversations.add(conv.alias);
+        this.monitoredAddresses.set(conv.address, conv.alias);
+      });
+    } catch (error) {
+      console.error("Error updating monitored conversations:", error);
+    }
+  }
+
+  private async processBlockEvent(event: BlockAddedData) {
+    try {
+      const blockTime =
+        Number(event?.data?.block?.header?.timestamp) || Date.now();
+      const transactions = event?.data?.block?.transactions || [];
+
+      // Process transactions silently
+      const txOutputsMap = new Map<string, ITransactionOutput[]>();
+      transactions.forEach((tx) => {
+        if (tx.outputs && tx.verboseData?.transactionId) {
+          txOutputsMap.set(tx.verboseData.transactionId, tx.outputs);
+        }
+      });
+
+      this.updateMonitoredConversations();
+
+      for (const tx of transactions) {
+        const txId = tx.verboseData?.transactionId;
+        if (!txId || this.processedMessageIds.has(txId)) continue;
+
+        if (isKasiaTransaction(tx)) {
+          // mark the txId as processed to avoid duplicate processing
+          this.processedMessageIds.add(txId);
+          if (this.processedMessageIds.size > this.MAX_PROCESSED_MESSAGES) {
+            const oldestId = this.processedMessageIds.values().next().value;
+
+            if (oldestId) {
+              this.processedMessageIds.delete(oldestId);
+            }
+          }
+
+          try {
+            // Process message transaction silently
+            await this.processMessageTransaction(tx, blockTime);
+          } catch (error) {
+            if (process.env.NODE_ENV === "development") {
+              console.debug("Error processing message transaction:", error);
+            }
+          }
+        }
+      }
+    } catch (error) {
+      console.error("Error processing block event:", error);
+    }
+  }
+
+  /**
+   * Helper function to handle SEC1 format compatibility
+   * for pre-encrypted messages
+   */
+  private adjustForSEC1Format(encryptedHex: string): string {
+    // Check if the key starts with 02 or 03 (compressed SEC1 format)
+    const keyStart = encryptedHex.substring(24, 26);
+    if (keyStart !== "02" && keyStart !== "03") {
+      return encryptedHex; // Not a SEC1 key, return unchanged
+    }
+
+    console.log("Detected SEC1 compressed key format in pre-encrypted message");
+
+    // Extract components
+    const nonce = encryptedHex.substring(0, 24);
+    const ephemeralPublicKey = encryptedHex.substring(24, 24 + 66);
+    const ciphertext = encryptedHex.substring(24 + 66);
+
+    // Extract the X coordinate (without the 02/03 prefix)
+    const publicKeyWithoutPrefix = ephemeralPublicKey.substring(2);
+
+    // The public key should be exactly 32 bytes (64 hex chars)
+    // If it's shorter, pad it with zeros at the end
+    const paddedPublicKey = publicKeyWithoutPrefix.padEnd(64, "0");
+
+    // Create new hex with padded public key
+    const modifiedHex = nonce + paddedPublicKey + ciphertext;
+    console.log("Adjusted hex for SEC1 format compatibility");
+
+    return modifiedHex;
+  }
+
+  private async processMessageTransaction(
+    tx: ITransaction | ExplorerTransaction,
+    blockTime: number,
+    maxRetries = 10
+  ) {
+    if (!this.password) return;
+
+    try {
+      const txId = getTransactionId(tx);
+
+      if (!txId) {
+        console.warn("Transaction ID is missing in real-time processing");
+        return;
+      }
+
+      if (
+        await useDBStore.getState().repositories.doesKasiaEventExistsById(txId)
+      ) {
+        console.log(`Transaction ${txId} already processed`);
+        return;
+      }
+
+      const walletAddress =
         this.unlockedWallet.publicKeyGenerator.receiveAddress(
           this.networkId,
           0
         );
+      const stringWalletAddress = walletAddress.toString();
 
-      // Ensure it has the proper network prefix
-      this.receiveAddress = new Address(
-        ensureAddressPrefix(initialReceiveAddress.toString(), this.networkId)
-      );
+      // 🚀 OPTIMIZATION: Skip if we know this transaction failed decryption before
+      if (DecryptionCache.hasFailed(stringWalletAddress, txId)) {
+        if (process.env.NODE_ENV === "development") {
+          console.debug(`Real-time: Skipping known failed decryption: ${txId}`);
+        }
+        return;
+      }
+      // Get sender address from transaction inputs
+      let senderAddress = null;
+      if (isITransaction(tx) && tx.inputs && tx.inputs.length > 0) {
+        const input = tx.inputs[0];
+        const prevTxId = input.previousOutpoint?.transactionId;
+        const prevOutputIndex = input.previousOutpoint?.index;
 
-      console.log(
-        "Using primary address for all operations:",
-        this.receiveAddress.toString()
-      );
+        if (prevTxId && typeof prevOutputIndex === "number") {
+          try {
+            const prevTx = await this._fetchTransactionDetails(
+              // this returns an explorer transaction
+              prevTxId,
+              maxRetries
+            );
+            if (prevTx?.outputs && prevTx.outputs[prevOutputIndex]) {
+              const output = prevTx.outputs[prevOutputIndex];
+              console.log("resolved sender address from prevTx: ", output);
+              senderAddress = output.script_public_key_address;
+            }
+          } catch (error) {
+            console.error("Error getting sender address:", error);
+          }
+        }
+      } else if (
+        isExplorerTransaction(tx) &&
+        tx.inputs &&
+        tx.inputs.length > 0
+      ) {
+        senderAddress = tx.inputs[0].previous_outpoint_address;
+      }
 
-      // Set up event listeners
-      console.log("Setting up event listeners...");
-      this.processor.addEventListener("balance", async () => {
-        console.log("Balance event received");
-        this._emitBalanceUpdate();
-      });
+      // If we still don't have a sender address, use the change output address
+      if (!senderAddress && tx.outputs && tx.outputs.length > 1) {
+        if (isITransaction(tx)) {
+          senderAddress = tx.outputs[1].verboseData?.scriptPublicKeyAddress;
+        } else {
+          senderAddress = tx.outputs[1].script_public_key_address;
+        }
+      }
 
-      // start the processor
-      console.log("Starting UTXO processor...");
-      await this.processor.start();
+      // Get the recipient address from the outputs
+      let recipientAddress = null;
+      if (tx.outputs && tx.outputs.length > 0) {
+        if (isITransaction(tx)) {
+          recipientAddress = tx.outputs[0].verboseData?.scriptPublicKeyAddress;
+        } else {
+          recipientAddress = tx.outputs[0].script_public_key_address;
+        }
+      }
 
-      // Only track primary address
-      const addressesToTrack = [this.receiveAddress];
-      await this.context.trackAddresses(addressesToTrack);
+      // If we still don't have a sender address, try to fetch it from the previous transaction
+      if (
+        !senderAddress &&
+        isExplorerTransaction(tx) &&
+        tx.inputs &&
+        tx.inputs.length > 0
+      ) {
+        // Try all inputs to find a valid sender address
+        for (let i = 0; i < tx.inputs.length; i++) {
+          const input = tx.inputs[i];
+          // previous_outpoint_hash
+          const prevTxId = input.previous_outpoint_hash;
+          const prevOutputIndex = parseInt(input.previous_outpoint_index);
 
-      // Set up block subscription with optimized message handling
-      console.log("Setting up block subscription...");
-      await this.rpcClient.subscribeToBlockAdded((event) => {
-        // Fire-and-forget; callback signature remains (event) => void
-        void this.processBlockEvent(event as unknown as BlockAddedData);
-      });
-      console.log("Successfully subscribed to block events");
+          if (prevTxId && !isNaN(prevOutputIndex)) {
+            try {
+              const prevTx = await this._fetchTransactionDetails(
+                prevTxId,
+                maxRetries
+              );
+              if (prevTx?.outputs && prevTx.outputs[prevOutputIndex]) {
+                const output = prevTx.outputs[prevOutputIndex];
+                senderAddress = output.script_public_key_address;
+                break;
+              }
+            } catch (error) {
+              console.error(
+                "Error getting sender address from previous transaction:",
+                error
+              );
+            }
+          }
+        }
+      }
 
-      this.isStarted = true;
-    } catch (error) {
-      console.error("Failed to start account service:", error);
-      throw error;
-    }
-  }
+      // Process the message
+      const payload = getTransactionPayload(tx);
+      if (!payload.startsWith(PROTOCOL.prefix.hex)) {
+        return;
+      }
 
-  async stop() {
-    console.log("Stopping UTXO subscription and processor...");
-    try {
-      // Stop the UTXO processor
-      await this.processor.stop();
+      const parsed = parseKaspaMessagePayload(tx.payload);
+      let messageType = parsed.type;
+      const targetAlias = parsed.alias;
 
-      // Clean up our local state
-      this.isStarted = false;
-      console.log("Successfully cleaned up UTXO subscription and processor");
+      const hexEncryptedPayload = tryBase64ToHex(parsed.encryptedHex);
+
+      const encryptedHex = hexEncryptedPayload;
+      let isHandshake = parsed.type === PROTOCOL.headers.HANDSHAKE.type;
+
+      const isMonitoredAddress =
+        (senderAddress && this.monitoredAddresses.has(senderAddress)) ||
+        (recipientAddress && this.monitoredAddresses.has(recipientAddress));
+      const isCommForUs =
+        messageType === PROTOCOL.headers.COMM.type &&
+        targetAlias &&
+        this.monitoredConversations.has(targetAlias);
+
+      // For payments, check if the sender address is one we're monitoring
+      // (i.e., we have a conversation with them OR they sent us a payment)
+      const isPaymentForUs =
+        messageType === PROTOCOL.headers.PAYMENT.type &&
+        (isMonitoredAddress ||
+          recipientAddress === this.receiveAddress?.toString());
+
+      try {
+        const privateKeyGenerator = WalletStorageService.getPrivateKeyGenerator(
+          this.unlockedWallet,
+          this.pwd
+        );
+
+        let decryptedContent = "";
+        let decryptionSuccess = false;
+
+        try {
+          const privateKey = privateKeyGenerator.receiveKey(0);
+          const txId = getTransactionId(tx);
+          if (!txId) {
+            throw new Error("Transaction ID is missing");
+          }
+          const result = await CipherHelper.tryDecrypt(
+            encryptedHex,
+            privateKey.toString(),
+            txId
+          );
+          decryptedContent = result;
+          decryptionSuccess = true;
+
+          if (
+            decryptedContent.includes(
+              `"type":"${PROTOCOL.headers.HANDSHAKE.type}"`
+            )
+          ) {
+            messageType = PROTOCOL.headers.HANDSHAKE.type;
+            isHandshake = true;
+            try {
+              // extract the JSON part
+              let jsonContent = decryptedContent;
+              if (
+                decryptedContent.includes(
+                  `${PROTOCOL.prefix.string}${PROTOCOL.headers.HANDSHAKE.string}`
+                )
+              ) {
+                jsonContent = decryptedContent.split(
+                  `${PROTOCOL.prefix.string}${PROTOCOL.headers.HANDSHAKE.string}`
+                )[1];
+              }
+              const handshakeData = JSON.parse(jsonContent);
+              if (handshakeData.isResponse) {
+                this.updateMonitoredConversations();
+              }
+            } catch (error) {
+              console.error("Error parsing handshake data:", error);
+            }
+          }
+        } catch (error) {
+          if (process.env.NODE_ENV === "development") {
+            console.debug(`Failed to decrypt with receive key:`, error);
+          }
+        }
+        if (!decryptionSuccess) {
+          try {
+            const privateKey = privateKeyGenerator.changeKey(0);
+            const txId = getTransactionId(tx);
+            if (!txId) {
+              throw new Error("Transaction ID is missing");
+            }
+            const result = await CipherHelper.tryDecrypt(
+              encryptedHex,
+              privateKey.toString(),
+              txId
+            );
+            decryptedContent = result;
+            decryptionSuccess = true;
+
+            if (
+              decryptedContent.includes(
+                `"type":"${PROTOCOL.headers.HANDSHAKE.type}"`
+              )
+            ) {
+              messageType = PROTOCOL.headers.HANDSHAKE.type;
+              isHandshake = true;
+              try {
+                // extract the JSON part
+                let jsonContent = decryptedContent;
+                if (
+                  decryptedContent.includes(
+                    `${PROTOCOL.prefix.string}${PROTOCOL.headers.HANDSHAKE.string}`
+                  )
+                ) {
+                  jsonContent = decryptedContent.split(
+                    `${PROTOCOL.prefix.string}${PROTOCOL.headers.HANDSHAKE.string}`
+                  )[1];
+                }
+                const handshakeData = JSON.parse(jsonContent);
+                if (handshakeData.isResponse) {
+                  this.updateMonitoredConversations();
+                }
+              } catch (error) {
+                console.error("Error parsing handshake data:", error);
+              }
+            }
+          } catch (error) {
+            if (process.env.NODE_ENV === "development") {
+              console.debug(`Failed to decrypt with change key:`, error);
+            }
+          }
+        }
+        // 🚀 OPTIMIZATION: Mark decryption result in cache
+        if (decryptionSuccess) {
+          DecryptionCache.markSuccess(stringWalletAddress, txId);
+          if (process.env.NODE_ENV === "development") {
+            console.debug(
+              `Real-time: Successful decryption for ${txId} - removed from failed cache if present`
+            );
+          }
+        } else {
+          DecryptionCache.markFailed(stringWalletAddress, txId);
+          if (process.env.NODE_ENV === "development") {
+            console.debug(
+              `Real-time: Failed decryption for ${txId} - marked as failed in cache`
+            );
+          }
+        }
+
+        if (
+          decryptionSuccess &&
+          (isHandshake || isMonitoredAddress || isCommForUs || isPaymentForUs)
+        ) {
+          const kasiaTransaction: KasiaTransaction = {
+            transactionId: txId,
+            senderAddress: senderAddress || "Unknown",
+            recipientAddress: recipientAddress || "Unknown",
+            createdAt: new Date(blockTime),
+            // @TODO(indexdb): how to get fees?
+            fee: 0,
+            content: decryptedContent,
+            amount:
+              Number(
+                isITransaction(tx) ? tx.outputs[0].value : tx.outputs[0].amount
+              ) / 100000000,
+            payload: tx.payload,
+          };
+
+          console.log("kasiaTransaction from account service", {
+            ...kasiaTransaction,
+          });
+
+          const messagingStore = useMessagingStore.getState();
+          if (messagingStore) {
+            await messagingStore.storeKasiaTransactions([kasiaTransaction]);
+          }
+
+          if (isHandshake) {
+            this.updateMonitoredConversations();
+          }
+
+          this.emit("messageReceived", kasiaTransaction);
+        }
+      } catch (error) {
+        console.error("Error processing message:", error);
+      }
     } catch (error) {
       console.error(
-        "Failed to clean up UTXO subscription and processor:",
+        `Error processing message transaction ${getTransactionId(tx)}:`,
         error
       );
     }
-  }
-
-  // Add method to set password
-  public setPassword(password: string) {
-    if (!password) {
-      throw new Error("Password cannot be empty");
-    }
-    console.log("Setting password in AccountService");
-    this.password = password;
   }
 
   public async createPaymentWithMessage(
@@ -785,119 +1204,131 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
     this.assertReady();
     return this.ctx.getMatureRange(0, this.ctx.matureLength);
   }
-
+=== Staging below
   private isKasiaTransaction(tx: ITransaction | ExplorerTransaction): boolean {
     return tx?.payload?.startsWith(PROTOCOL.prefix.hex) ?? false;
   }
 
   private async processMessageTransaction(
-    tx: ITransaction,
+    tx: ITransaction | ExplorerTransaction,
     blockTime: number,
     maxRetries = 10
   ) {
     if (!this.password) return;
 
-    const payload = tx.payload;
-    if (!payload.startsWith(PROTOCOL.prefix.hex)) {
-      return;
-    }
+    try {
+      const txId = getTransactionId(tx);
 
-    const txId = getTransactionId(tx);
-
-    if (!txId) {
-      console.warn("Transaction ID is missing in real-time processing");
-      return;
-    }
-
-    if (
-      await useDBStore.getState().repositories.doesKasiaEventExistsById(txId)
-    ) {
-      console.log(`Transaction ${txId} already processed`);
-      return;
-    }
-
-    // note: ideally we wouldn't need to compute the address once more
-    // if this is needed, it means the loading strategy is wrong
-    // and should queue added block events before ingesting them
-    const walletAddress = this.unlockedWallet.publicKeyGenerator.receiveAddress(
-      this.networkId,
-      0
-    );
-    const stringWalletAddress = walletAddress.toString();
-
-    if (DecryptionCache.hasFailed(stringWalletAddress, txId)) {
-      if (process.env.NODE_ENV === "development") {
-        console.debug(`Real-time: Skipping known failed decryption: ${txId}`);
+      if (!txId) {
+        console.warn("Transaction ID is missing in real-time processing");
+        return;
       }
-      return;
-    }
 
-    // Get sender address from transaction inputs
-    let senderAddress = null;
-    if (tx.inputs && tx.inputs.length > 0) {
-      const input = tx.inputs[0];
-      const prevTxId = input.previousOutpoint?.transactionId;
-      const prevOutputIndex = input.previousOutpoint?.index;
+      if (
+        await useDBStore.getState().repositories.doesKasiaEventExistsById(txId)
+      ) {
+        console.log(`Transaction ${txId} already processed`);
+        return;
+      }
 
-      if (prevTxId && typeof prevOutputIndex === "number") {
-        try {
-          const prevTx = await this._fetchTransactionDetails(
-            // this returns an explorer transaction
-            prevTxId,
-            maxRetries
-          );
-          if (prevTx?.outputs && prevTx.outputs[prevOutputIndex]) {
-            const output = prevTx.outputs[prevOutputIndex];
-            console.log("resolved sender address from prevTx: ", output);
-            senderAddress = output.script_public_key_address;
-          }
-        } catch (error) {
-          console.error("Error getting sender address:", error);
+      const walletAddress =
+        this.unlockedWallet.publicKeyGenerator.receiveAddress(
+          this.networkId,
+          0
+        );
+      const stringWalletAddress = walletAddress.toString();
+
+      // 🚀 OPTIMIZATION: Skip if we know this transaction failed decryption before
+      if (DecryptionCache.hasFailed(stringWalletAddress, txId)) {
+        if (process.env.NODE_ENV === "development") {
+          console.debug(`Real-time: Skipping known failed decryption: ${txId}`);
         }
+        return;
       }
-    }
+      // Get sender address from transaction inputs
+      let senderAddress = null;
+      if (isITransaction(tx) && tx.inputs && tx.inputs.length > 0) {
+        const input = tx.inputs[0];
+        const prevTxId = input.previousOutpoint?.transactionId;
+        const prevOutputIndex = input.previousOutpoint?.index;
 
-    // @TODO(indexer): shouldn't use this fallback, can lead to fake id.
-    // If we still don't have a sender address, use the change output address
-    if (!senderAddress && tx.outputs && tx.outputs.length > 1) {
-      senderAddress = tx.outputs[1].verboseData?.scriptPublicKeyAddress;
-    }
-
-    // Get the recipient address from the outputs
-    let recipientAddress = null;
-    if (tx.outputs && tx.outputs.length > 0) {
-      recipientAddress = tx.outputs[0].verboseData?.scriptPublicKeyAddress;
-    }
-
-    // If we still don't have a sender address, try to fetch it from the previous transaction
-    if (!senderAddress && tx.inputs && tx.inputs.length > 0) {
-      // Try all inputs to find a valid sender address
-      for (let i = 0; i < tx.inputs.length; i++) {
-        const input = tx.inputs[i];
-        // previous_outpoint_hash
-        const prevTxId = input.previousOutpoint.transactionId;
-        const prevOutputIndex = input.previousOutpoint.index;
-
-            if (prevTxId) {
+        if (prevTxId && typeof prevOutputIndex === "number") {
           try {
             const prevTx = await this._fetchTransactionDetails(
+              // this returns an explorer transaction
               prevTxId,
               maxRetries
             );
             if (prevTx?.outputs && prevTx.outputs[prevOutputIndex]) {
               const output = prevTx.outputs[prevOutputIndex];
+              console.log("resolved sender address from prevTx: ", output);
               senderAddress = output.script_public_key_address;
-              break;
             }
           } catch (error) {
-            console.error(
-              "Error getting sender address from previous transaction:",
-              error
-            );
+            console.error("Error getting sender address:", error);
+          }
+        }
+      } else if (
+        isExplorerTransaction(tx) &&
+        tx.inputs &&
+        tx.inputs.length > 0
+      ) {
+        senderAddress = tx.inputs[0].previous_outpoint_address;
+      }
+
+      // If we still don't have a sender address, use the change output address
+      if (!senderAddress && tx.outputs && tx.outputs.length > 1) {
+        if (isITransaction(tx)) {
+          senderAddress = tx.outputs[1].verboseData?.scriptPublicKeyAddress;
+        } else {
+          senderAddress = tx.outputs[1].script_public_key_address;
+        }
+      }
+
+      // Get the recipient address from the outputs
+      let recipientAddress = null;
+      if (tx.outputs && tx.outputs.length > 0) {
+        if (isITransaction(tx)) {
+          recipientAddress = tx.outputs[0].verboseData?.scriptPublicKeyAddress;
+        } else {
+          recipientAddress = tx.outputs[0].script_public_key_address;
+        }
+      }
+
+      // If we still don't have a sender address, try to fetch it from the previous transaction
+      if (
+        !senderAddress &&
+        isExplorerTransaction(tx) &&
+        tx.inputs &&
+        tx.inputs.length > 0
+      ) {
+        // Try all inputs to find a valid sender address
+        for (let i = 0; i < tx.inputs.length; i++) {
+          const input = tx.inputs[i];
+          // previous_outpoint_hash
+          const prevTxId = input.previous_outpoint_hash;
+          const prevOutputIndex = parseInt(input.previous_outpoint_index);
+
+          if (prevTxId && !isNaN(prevOutputIndex)) {
+            try {
+              const prevTx = await this._fetchTransactionDetails(
+                prevTxId,
+                maxRetries
+              );
+              if (prevTx?.outputs && prevTx.outputs[prevOutputIndex]) {
+                const output = prevTx.outputs[prevOutputIndex];
+                senderAddress = output.script_public_key_address;
+                break;
+              }
+            } catch (error) {
+              console.error(
+                "Error getting sender address from previous transaction:",
+                error
+              );
+            }
           }
         }
       }
-    }
 
       // Process the message
       const payload = getTransactionPayload(tx);
@@ -905,51 +1336,6 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
         return;
       }
 
-    const parsed = parseKaspaMessagePayload(tx.payload);
-
-    const messageType = parsed.type;
-    const targetAlias = parsed.alias;
-
-    // @TODO: check how to do hex manipulation properly, currently parsed.encryptedHex is a hex
-    // if we want to handle base64, it would need to find a way to do from/to hex properly in JS
-    // from my tests, it seems that the utils alters the hex
-    const hexEncryptedPayload = tryParseBase64AsHexToHex(parsed.encryptedHex);
-
-    const encryptedHex = hexEncryptedPayload;
-    const isHandshake = parsed.type === PROTOCOL.headers.HANDSHAKE.type;
-
-    const isMonitoredAddress =
-      (senderAddress && this.monitoredAddresses.has(senderAddress)) ||
-      (recipientAddress && this.monitoredAddresses.has(recipientAddress));
-    const isCommForUs =
-      messageType === PROTOCOL.headers.COMM.type &&
-      targetAlias &&
-      this.monitoredConversations.has(targetAlias);
-
-    // For payments, check if the sender address is one we're monitoring
-    // (i.e., we have a conversation with them OR they sent us a payment)
-    const isPaymentForUs =
-      messageType === PROTOCOL.headers.PAYMENT.type &&
-      (isMonitoredAddress ||
-        recipientAddress === this.receiveAddress?.toString());
-
-    try {
-      // note: same remark as earlier in the flow
-      // here we should need to re-generate the key because the context should already
-      // be unlocked, unless there is a logical error in the general loading strategy
-      const privateKeyGenerator = WalletStorageService.getPrivateKeyGenerator(
-        this.unlockedWallet,
-        this.password!
-      );
-
-      let decryptionSuccess = false;
-
-      try {
-        const privateKey = privateKeyGenerator.receiveKey(0);
-======RESOLVE +
-        const decryptedContent = decrypt_message(
-          new EncryptedMessage(encryptedHex),
-          new PrivateKey(privateKey.toString())
       const parsed = parseKaspaMessagePayload(tx.payload);
       let messageType = parsed.type;
       const targetAlias = parsed.alias;
@@ -979,9 +1365,106 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
           this.unlockedWallet,
           this.pwd
         );
-======RESOLVE +
-        decryptionSuccess = true;
 
+        let decryptedContent = "";
+        let decryptionSuccess = false;
+
+        try {
+          const privateKey = privateKeyGenerator.receiveKey(0);
+          const txId = getTransactionId(tx);
+          if (!txId) {
+            throw new Error("Transaction ID is missing");
+          }
+          const result = await CipherHelper.tryDecrypt(
+            encryptedHex,
+            privateKey.toString(),
+            txId
+          );
+          decryptedContent = result;
+          decryptionSuccess = true;
+
+          if (
+            decryptedContent.includes(
+              `"type":"${PROTOCOL.headers.HANDSHAKE.type}"`
+            )
+          ) {
+            messageType = PROTOCOL.headers.HANDSHAKE.type;
+            isHandshake = true;
+            try {
+              // extract the JSON part
+              let jsonContent = decryptedContent;
+              if (
+                decryptedContent.includes(
+                  `${PROTOCOL.prefix.string}${PROTOCOL.headers.HANDSHAKE.string}`
+                )
+              ) {
+                jsonContent = decryptedContent.split(
+                  `${PROTOCOL.prefix.string}${PROTOCOL.headers.HANDSHAKE.string}`
+                )[1];
+              }
+              const handshakeData = JSON.parse(jsonContent);
+              if (handshakeData.isResponse) {
+                this.updateMonitoredConversations();
+              }
+            } catch (error) {
+              console.error("Error parsing handshake data:", error);
+            }
+          }
+        } catch (error) {
+          if (process.env.NODE_ENV === "development") {
+            console.debug(`Failed to decrypt with receive key:`, error);
+          }
+        }
+        === Staging ABOVE
+        if (!decryptionSuccess) {
+          try {
+            const privateKey = privateKeyGenerator.changeKey(0);
+            const txId = getTransactionId(tx);
+            if (!txId) {
+              throw new Error("Transaction ID is missing");
+            }
+            const result = await CipherHelper.tryDecrypt(
+              encryptedHex,
+              privateKey.toString(),
+              txId
+            );
+            decryptedContent = result;
+            decryptionSuccess = true;
+
+            if (
+              decryptedContent.includes(
+                `"type":"${PROTOCOL.headers.HANDSHAKE.type}"`
+              )
+            ) {
+              messageType = PROTOCOL.headers.HANDSHAKE.type;
+              isHandshake = true;
+              try {
+                // extract the JSON part
+                let jsonContent = decryptedContent;
+                if (
+                  decryptedContent.includes(
+                    `${PROTOCOL.prefix.string}${PROTOCOL.headers.HANDSHAKE.string}`
+                  )
+                ) {
+                  jsonContent = decryptedContent.split(
+                    `${PROTOCOL.prefix.string}${PROTOCOL.headers.HANDSHAKE.string}`
+                  )[1];
+                }
+                const handshakeData = JSON.parse(jsonContent);
+                if (handshakeData.isResponse) {
+                  this.updateMonitoredConversations();
+                }
+              } catch (error) {
+                console.error("Error parsing handshake data:", error);
+              }
+            }
+          } catch (error) {
+            if (process.env.NODE_ENV === "development") {
+              console.debug(`Failed to decrypt with change key:`, error);
+            }
+          }
+        }
+        // 🚀 OPTIMIZATION: Mark decryption result in cache
         if (decryptionSuccess) {
           DecryptionCache.markSuccess(stringWalletAddress, txId);
           if (process.env.NODE_ENV === "development") {
@@ -1002,22 +1485,6 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
           decryptionSuccess &&
           (isHandshake || isMonitoredAddress || isCommForUs || isPaymentForUs)
         ) {
-          // this hack is necessary because we have inconsistencies between data parsed at historical level
-          // , at live level (here is live level), and when client is the creator of the event
-          // so be "re-build" it like the other places, ideally this shouldn't be necessary
-          let hackedContent = decryptedContent;
-
-          if (parsed.type === "handshake") {
-            // handhshake payload is expected to be utf-8 encoded
-            hackedContent = `${PROTOCOL.prefix.string}${PROTOCOL.headers.HANDSHAKE.string}${decryptedContent}`;
-          } else if (parsed.type === "message") {
-            // message payload is expected to be hex encoded
-            hackedContent = `${PROTOCOL.prefix.hex}${PROTOCOL.headers.COMM.hex}${toHex(parsed.alias ?? "UNKNOWN")}:${decryptedContent}`;
-          } else if (parsed.type === "payment") {
-            // payment payload is expected to be hex encoded
-            hackedContent = `${PROTOCOL.prefix.hex}${PROTOCOL.headers.PAYMENT.hex}${decryptedContent}`;
-          }
-
           const kasiaTransaction: KasiaTransaction = {
             transactionId: txId,
             senderAddress: senderAddress || "Unknown",
@@ -1025,8 +1492,11 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
             createdAt: new Date(blockTime),
             // @TODO(indexdb): how to get fees?
             fee: 0,
-            content: hackedContent,
-            amount: Number(tx.outputs[0].value) / 100000000,
+            content: decryptedContent,
+            amount:
+              Number(
+                isITransaction(tx) ? tx.outputs[0].value : tx.outputs[0].amount
+              ) / 100000000,
             payload: tx.payload,
           };
 
@@ -1038,6 +1508,12 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
           if (messagingStore) {
             await messagingStore.storeKasiaTransactions([kasiaTransaction]);
           }
+
+          if (isHandshake) {
+            this.updateMonitoredConversations();
+          }
+
+          this.emit("messageReceived", kasiaTransaction);
         }
       } catch (error) {
         console.error("Error processing message:", error);
@@ -1146,7 +1622,6 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
     }
   }
 
-  // note: account service should not be responsible for handling block added logic
   private async processBlockEvent(event: BlockAddedData) {
     try {
       const blockTime =
@@ -1161,9 +1636,6 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
         }
       });
 
-      // note: this should be optimized, account service shouldn't be the owner of that
-      // it shouldn't be needed to refresh computation here if the owner of this would be the
-      // maintainer of the shared state
       this.updateMonitoredConversations();
 
       for (const tx of transactions) {
@@ -1171,7 +1643,6 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
         if (!txId || this.processedMessageIds.has(txId)) continue;
 
         if (this.isKasiaTransaction(tx)) {
-          console.log("found a kasia transaction", { tx });
           // mark the txId as processed to avoid duplicate processing
           this.processedMessageIds.add(txId);
           if (this.processedMessageIds.size > this.MAX_PROCESSED_MESSAGES) {
@@ -1183,6 +1654,7 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
           }
 
           try {
+            // Process message transaction silently
             await this.processMessageTransaction(tx, blockTime);
           } catch (error) {
             if (process.env.NODE_ENV === "development") {

--- a/src/service/account-service.ts
+++ b/src/service/account-service.ts
@@ -121,6 +121,25 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
   // Add password field
   private password: string | null = null;
 
+  private get rpc() {
+    if (!this.rpcClient.rpc) throw new Error("RPC client is not initialized");
+    return this.rpcClient.rpc;
+  }
+  private get recv(): Address {
+    if (!this.receiveAddress)
+      throw new Error("Receive address not initialized");
+    return this.receiveAddress;
+  }
+  private get ctx(): UtxoContext {
+    if (!this.context) throw new Error("UTXO context not initialized");
+    return this.context;
+  }
+  private get pwd(): string {
+    if (!this.password)
+      throw new Error("Password not set - cannot perform operation");
+    return this.password;
+  }
+
   constructor(
     private readonly rpcClient: KaspaClient,
     private readonly unlockedWallet: UnlockedWallet
@@ -143,15 +162,6 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
     if (unlockedWallet.password) {
       this.password = unlockedWallet.password;
     }
-  }
-
-  // Add method to set password
-  public setPassword(password: string) {
-    if (!password) {
-      throw new Error("Password cannot be empty");
-    }
-    console.log("Setting password in AccountService");
-    this.password = password;
   }
 
   private _emitBalanceUpdate() {
@@ -251,25 +261,6 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
     if (!this.context) throw new Error("UTXO context not initialized");
     if (!this.password)
       throw new Error("Password not set - cannot perform operation");
-  }
-
-  private get rpc() {
-    if (!this.rpcClient.rpc) throw new Error("RPC client is not initialized");
-    return this.rpcClient.rpc;
-  }
-  private get recv(): Address {
-    if (!this.receiveAddress)
-      throw new Error("Receive address not initialized");
-    return this.receiveAddress;
-  }
-  private get ctx(): UtxoContext {
-    if (!this.context) throw new Error("UTXO context not initialized");
-    return this.context;
-  }
-  private get pwd(): string {
-    if (!this.password)
-      throw new Error("Password not set - cannot perform operation");
-    return this.password;
   }
 
   private async createTransaction(
@@ -442,6 +433,15 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
         error
       );
     }
+  }
+
+  // Add method to set password
+  public setPassword(password: string) {
+    if (!password) {
+      throw new Error("Password cannot be empty");
+    }
+    console.log("Setting password in AccountService");
+    this.password = password;
   }
 
   public async createPaymentWithMessage(

--- a/src/service/transaction-generator.ts
+++ b/src/service/transaction-generator.ts
@@ -124,11 +124,8 @@ export class TransactionGeneratorService {
     payload?: string | Uint8Array;
     priorityFee?: PriorityFeeConfig;
   }): Generator {
-    const isFullBalance = amount >= (context.balance?.mature ?? 0n);
-
-    const changeAddress = isFullBalance
-      ? new Address(destinationAddress.toString())
-      : receiveAddress;
+    const matureBalance = context.balance?.mature ?? 0n;
+    const isFullBalance = matureBalance === amount;
 
     // for full balance, use ReceiverPays (no choice). For partial, use SenderPays
     const finalPriorityFee = isFullBalance
@@ -139,14 +136,13 @@ export class TransactionGeneratorService {
         };
 
     const settings: IGeneratorSettingsObject = {
-      changeAddress,
+      changeAddress: receiveAddress,
       entries: context,
       outputs: [new PaymentOutput(destinationAddress, amount)],
       networkId,
       priorityFee: finalPriorityFee,
       ...(payload && { payload }),
     };
-
     return new Generator(settings);
   }
 }

--- a/src/service/transaction-generator.ts
+++ b/src/service/transaction-generator.ts
@@ -1,0 +1,152 @@
+import {
+  Address,
+  UtxoContext,
+  Generator,
+  PaymentOutput,
+  FeeSource,
+  IGeneratorSettingsObject,
+} from "kaspa-wasm";
+import { PriorityFeeConfig } from "../types/all";
+
+export class TransactionGeneratorService {
+  /**
+   * Create generator for regular transactions with payload (messages)
+   */
+  static createForTransaction({
+    context,
+    networkId,
+    receiveAddress,
+    destinationAddress,
+    amount,
+    payload,
+    priorityFee,
+  }: {
+    context: UtxoContext;
+    networkId: string;
+    receiveAddress: Address;
+    destinationAddress: Address;
+    amount: bigint;
+    payload: string | Uint8Array;
+    priorityFee?: PriorityFeeConfig;
+  }): Generator {
+    // Check if this is a direct self-message (sending to our own receive address)
+    const isDirectSelfMessage =
+      destinationAddress.toString() === receiveAddress.toString();
+
+    console.log(isDirectSelfMessage);
+    // For regular transactions, always use the specified amount and destination
+    // For self-messages, use empty outputs array to only use change output
+    const outputs = isDirectSelfMessage
+      ? []
+      : [new PaymentOutput(destinationAddress, amount)];
+
+    // Calculate additional fee based on fee rate difference
+    let additionalFee = BigInt(0);
+
+    if (priorityFee?.feerate && priorityFee.feerate > 1) {
+      // Estimate transaction mass (typical message transaction ~2500-3000 grams)
+      const estimatedMass = 2800; // grams - rough estimate for message transaction
+      const baseFeeRate = 1; // sompi per gram
+      const additionalFeeRate = priorityFee.feerate - baseFeeRate;
+      additionalFee = BigInt(Math.floor(additionalFeeRate * estimatedMass));
+
+      console.log("Calculated additional priority fee:", {
+        selectedFeeRate: priorityFee.feerate,
+        baseFeeRate,
+        additionalFeeRate,
+        estimatedMass,
+        additionalFeeSompi: additionalFee.toString(),
+        additionalFeeKAS: Number(additionalFee) / 100_000_000,
+      });
+    } else if (priorityFee?.amount && priorityFee.amount > 0) {
+      additionalFee = priorityFee.amount;
+      console.log(
+        "Using explicit priority fee amount:",
+        additionalFee.toString()
+      );
+    }
+
+    console.log("Final priority fee for Generator:", additionalFee.toString());
+
+    const settings: IGeneratorSettingsObject = {
+      changeAddress: receiveAddress,
+      entries: context,
+      outputs: outputs,
+      payload,
+      networkId,
+      priorityFee: additionalFee,
+    };
+
+    return new Generator(settings);
+  }
+
+  /**
+   * Create generator for compound transactions (UTXO consolidation)
+   */
+  static createForCompound({
+    context,
+    networkId,
+    receiveAddress,
+  }: {
+    context: UtxoContext;
+    networkId: string;
+    receiveAddress: Address;
+  }): Generator {
+    // compound transaction - sweep operation to consolidate UTXOs
+    // for compound tx, we pass undefined to outputs which means we dont need to specify priority fee
+    const settings: IGeneratorSettingsObject = {
+      changeAddress: receiveAddress,
+      entries: context,
+      outputs: undefined as unknown as PaymentOutput[],
+      networkId,
+    };
+
+    return new Generator(settings);
+  }
+
+  /**
+   * Create generator for payment and withdrawal transactions
+   */
+  static createForPaymentOrWithdraw({
+    context,
+    networkId,
+    receiveAddress,
+    destinationAddress,
+    amount,
+    payload,
+    priorityFee,
+  }: {
+    context: UtxoContext;
+    networkId: string;
+    receiveAddress: Address;
+    destinationAddress: Address;
+    amount: bigint;
+    payload?: string | Uint8Array;
+    priorityFee?: PriorityFeeConfig;
+  }): Generator {
+    const isFullBalance = amount >= (context.balance?.mature ?? 0n);
+
+    const changeAddress = isFullBalance
+      ? new Address(destinationAddress.toString())
+      : receiveAddress;
+
+    // for full balance, use ReceiverPays (no choice). For partial, use SenderPays
+    const finalPriorityFee = isFullBalance
+      ? { amount: BigInt(0), source: FeeSource.ReceiverPays }
+      : priorityFee || {
+          amount: BigInt(0),
+          source: FeeSource.SenderPays,
+        };
+
+    const settings: IGeneratorSettingsObject = {
+      changeAddress,
+      entries: context,
+      outputs: [new PaymentOutput(destinationAddress, amount)],
+      networkId,
+      priorityFee: finalPriorityFee,
+      ...(payload && { payload }),
+    };
+
+    return new Generator(settings);
+  }
+}

--- a/src/service/transaction-generator.ts
+++ b/src/service/transaction-generator.ts
@@ -45,6 +45,7 @@ export class TransactionGeneratorService {
 
     if (priorityFee?.feerate && priorityFee.feerate > 1) {
       // Estimate transaction mass (typical message transaction ~2500-3000 grams)
+      // TO DO: Fix this.
       const estimatedMass = 2800; // grams - rough estimate for message transaction
       const baseFeeRate = 1; // sompi per gram
       const additionalFeeRate = priorityFee.feerate - baseFeeRate;
@@ -115,6 +116,7 @@ export class TransactionGeneratorService {
     amount,
     payload,
     priorityFee,
+    isFullBalance,
   }: {
     context: UtxoContext;
     networkId: string;
@@ -123,10 +125,8 @@ export class TransactionGeneratorService {
     amount: bigint;
     payload?: string | Uint8Array;
     priorityFee?: PriorityFeeConfig;
+    isFullBalance?: boolean;
   }): Generator {
-    const matureBalance = context.balance?.mature ?? 0n;
-    const isFullBalance = matureBalance === amount;
-
     // for full balance, use ReceiverPays (no choice). For partial, use SenderPays
     const finalPriorityFee = isFullBalance
       ? { amount: BigInt(0), source: FeeSource.ReceiverPays }

--- a/src/store/message-composer.store.ts
+++ b/src/store/message-composer.store.ts
@@ -7,6 +7,7 @@ export type Attachment = FileData | null;
 
 interface ComposerState {
   drafts: Record<string, string>;
+
   attachment: Attachment | null;
   priority: PriorityFeeConfig;
 

--- a/src/store/ui.store.ts
+++ b/src/store/ui.store.ts
@@ -15,7 +15,6 @@ export type ModalType =
   | "backup"
   | "delete"
   | "seed"
-  | "utxo-compound"
   | "settings"
   | "contact-info-modal"
   | "image";

--- a/src/store/wallet.store.ts
+++ b/src/store/wallet.store.ts
@@ -19,7 +19,6 @@ import {
 import { TransactionId } from "../types/transactions";
 import { PriorityFeeConfig } from "../types/all";
 import { FEE_ESTIMATE_POLLING_INTERVAL_IN_MS } from "../config/constants";
-import { get } from "http";
 
 export interface WalletStoreSendMessageArgs {
   /**
@@ -363,14 +362,12 @@ export const useWalletStore = create<WalletState>((set, get) => {
       if (!state.unlockedWallet || !state.accountService) {
         throw new Error("Wallet not unlocked or account service not running");
       }
-      return state.accountService.createTransaction(
-        {
-          address: args.toAddress,
-          amount: args.customAmount ?? BigInt(0),
-          payload: args.payload ?? "",
-          priorityFee: args.priorityFee,
-        }
-      );
+      return state.accountService.sendMessage({
+        toAddress: args.toAddress,
+        message: args.payload ?? "",
+        amount: args.customAmount ?? BigInt(0),
+        priorityFee: args.priorityFee,
+      });
     },
     sendMessageWithContext: async ({
       message,

--- a/src/store/wallet.store.ts
+++ b/src/store/wallet.store.ts
@@ -362,9 +362,9 @@ export const useWalletStore = create<WalletState>((set, get) => {
       if (!state.unlockedWallet || !state.accountService) {
         throw new Error("Wallet not unlocked or account service not running");
       }
-      return state.accountService.sendMessage({
-        toAddress: args.toAddress,
-        message: args.payload ?? "",
+      return state.accountService.createTransaction({
+        address: args.toAddress,
+        payload: args.payload ?? "",
         amount: args.customAmount ?? BigInt(0),
         priorityFee: args.priorityFee,
       });

--- a/src/store/wallet.store.ts
+++ b/src/store/wallet.store.ts
@@ -27,7 +27,6 @@ export interface WalletStoreSendMessageArgs {
    */
   message: string;
   toAddress: Address;
-  password: string;
   customAmount?: bigint;
   priorityFee?: PriorityFeeConfig;
 }
@@ -36,7 +35,17 @@ export interface WalletStoreSendContextualMessageArgs {
   message: string;
   toAddress: Address;
   myAlias: string;
+  priorityFee?: PriorityFeeConfig;
+}
+
+export interface WalletStoreSendTransactionArgs {
+  /**
+   * payload to use for the transaction, if encryption is required, it should be encrypted before passing it here
+   */
+  payload?: string;
+  toAddress: Address;
   password: string;
+  customAmount?: bigint;
   priorityFee?: PriorityFeeConfig;
 }
 
@@ -360,14 +369,12 @@ export const useWalletStore = create<WalletState>((set, get) => {
           amount: args.customAmount ?? BigInt(0),
           payload: args.payload ?? "",
           priorityFee: args.priorityFee,
-        },
-        state.unlockedWallet.password
+        }
       );
     },
     sendMessageWithContext: async ({
       message,
       toAddress,
-      password,
       priorityFee,
       myAlias,
     }) => {
@@ -384,7 +391,6 @@ export const useWalletStore = create<WalletState>((set, get) => {
         return await state.accountService.sendMessageWithContext({
           message: encryptedMessage.to_hex(),
           toAddress,
-          password,
           theirAlias: myAlias,
           priorityFee,
         });

--- a/src/tests/protocol.test.ts
+++ b/src/tests/protocol.test.ts
@@ -23,5 +23,19 @@ it("should parse message", async () => {
   const parsed = parseKaspaMessagePayload(message);
 
   expect(parsed.encryptedHex).toBe(encryptedHex);
+  expect(parsed.type).toBe("comm");
   expect(parsed.alias).toBe(expectedAlias);
+});
+
+it("should parse payment", async () => {
+  const message =
+    "636970685f6d73673a313a7061796d656e743a7b2274797065223a227061796d656e74222c226d657373616765223a2268656c6c6f20776f726c64222c22616d6f756e74223a302e35323334353637382c2274696d657374616d70223a313735353930373739333033322c2276657273696f6e223a317d";
+  const encryptedHex =
+    "7b2274797065223a227061796d656e74222c226d657373616765223a2268656c6c6f20776f726c64222c22616d6f756e74223a302e35323334353637382c2274696d657374616d70223a313735353930373739333033322c2276657273696f6e223a317d";
+
+  const parsed = parseKaspaMessagePayload(message);
+
+  expect(parsed.encryptedHex).toBe(encryptedHex);
+  expect(parsed.type).toBe("payment");
+  expect(parsed.alias).toBe(undefined);
 });

--- a/src/utils/message-payload.ts
+++ b/src/utils/message-payload.ts
@@ -57,8 +57,9 @@ export function parseKaspaMessagePayload(
     // 1:payment:xyz
     if (parts.length >= 3) {
       type = PROTOCOL.headers.PAYMENT.type;
+      // extract the encrypted hex part after "1:payment:"
       encryptedHex = payloadWithoutPrefix.substr(
-        PROTOCOL.headers.PAYMENT.hex.length + 2
+        PROTOCOL.headers.PAYMENT.hex.length
       );
     }
   }

--- a/src/utils/message-payload.ts
+++ b/src/utils/message-payload.ts
@@ -1,5 +1,7 @@
 import { PROTOCOL } from "../config/protocol";
 import { hexToString } from "./format";
+import { ITransaction } from "wasm/kaspa";
+import { ExplorerTransaction } from "../types/transactions";
 
 export type ParsedKaspaMessagePayload = {
   type: string;
@@ -62,4 +64,10 @@ export function parseKaspaMessagePayload(
   }
 
   return { type, alias, encryptedHex };
+}
+
+export function isKasiaTransaction(
+  tx: ITransaction | ExplorerTransaction
+): boolean {
+  return tx?.payload?.startsWith(PROTOCOL.prefix.hex) ?? false;
 }

--- a/src/utils/network.ts
+++ b/src/utils/network.ts
@@ -3,9 +3,32 @@ import { NetworkType } from "kaspa-wasm";
 // Helper function to determine network type from address
 export function getNetworkTypeFromAddress(address: string): NetworkType {
   if (address.startsWith("kaspatest:")) {
-    return NetworkType.Mainnet;
+    return NetworkType.Testnet;
   } else if (address.startsWith("kaspadev:")) {
     return NetworkType.Devnet;
   }
   return NetworkType.Mainnet;
+}
+
+// Helper function to ensure an address has the proper network prefix
+export function ensureAddressPrefix(
+  address: string,
+  networkId: string
+): string {
+  // If address already has a prefix, return it unchanged
+  if (address.includes(":")) {
+    return address;
+  }
+
+  // Add appropriate prefix based on network
+  if (networkId === "testnet-10" || networkId === "testnet-11") {
+    return `kaspatest:${address}`;
+  } else if (networkId === "mainnet") {
+    return `kaspa:${address}`;
+  } else if (networkId === "devnet") {
+    return `kaspadev:${address}`;
+  }
+
+  // Default to mainnet if network is unknown
+  return `kaspa:${address}`;
 }

--- a/src/utils/payload-encoding.ts
+++ b/src/utils/payload-encoding.ts
@@ -34,11 +34,19 @@ export const tryParseBase64AsHexToHex = (input: string): string => {
 };
 
 // check if payload is a message transaction (both hex and base64 formats)
-export const isMessagePayload = (p: string | Uint8Array): boolean =>
-  !!p &&
-  (typeof p === "string"
-    ? p.startsWith(PROTOCOL.prefix.hex) || p.startsWith("ciph_msg:")
-    : false);
+export const isMessagePayload = (p: string | Uint8Array): boolean => {
+  if (!p) return false;
+
+  if (typeof p === "string") {
+    return p.startsWith(PROTOCOL.prefix.hex) || p.startsWith("ciph_msg:1:comm");
+  }
+
+  // handle Uint8Array by converting to string
+  const str = new TextDecoder().decode(p.slice(0, 30)); // check first 20 bytes
+  return (
+    str.startsWith(PROTOCOL.prefix.hex) || str.startsWith("ciph_msg:1:comm")
+  );
+};
 
 // get encoder singleton for reuse
 export const getEncoder = () => _encoder;

--- a/src/utils/payload-encoding.ts
+++ b/src/utils/payload-encoding.ts
@@ -33,21 +33,6 @@ export const tryParseBase64AsHexToHex = (input: string): string => {
   return base64ToHex(content);
 };
 
-// check if payload is a message transaction (both hex and base64 formats)
-export const isMessagePayload = (p: string | Uint8Array): boolean => {
-  if (!p) return false;
-
-  if (typeof p === "string") {
-    return p.startsWith(PROTOCOL.prefix.hex) || p.startsWith("ciph_msg:1:comm");
-  }
-
-  // handle Uint8Array by converting to string
-  const str = new TextDecoder().decode(p.slice(0, 30)); // check first 20 bytes
-  return (
-    str.startsWith(PROTOCOL.prefix.hex) || str.startsWith("ciph_msg:1:comm")
-  );
-};
-
 // get encoder singleton for reuse
 export const getEncoder = () => _encoder;
 


### PR DESCRIPTION
## what
- removes utxo-compound modal and makes it part of wallet info (styling etc)
- restyles walletinfo
- refactors a LOT to do with `account-service`, moving a bunch of stuff around, renaming functions, removing password prop passing, changed some of the guards to assert themselves instead. refactor sign and submit into one private helper function, adding fee guard at the start of it etc.
- move the generators to their own service, fixed the generators so the work correctly
- fix ux on fee estimation:
  - if not funds, don't estimate fee (we cant!)
  - when funds come, allow the estimate to kick off again, so in a
  situation where we have text in the box, itll re-hydrate and calc.
- misc styling across the app