### PR TITLE
Fix/send all and utxo context updates. Walllet Info Style. Tx flow refactor

### DIFF
--- a/src/components/Modals/WalletInfo.tsx
+++ b/src/components/Modals/WalletInfo.tsx
@@ -33,11 +33,27 @@ export const WalletInfo = () => {
           <h4 className="text-text-primary me-2 font-bold">Wallet Name:</h4>
           <div className="text-base font-semibold">{unlockedWalletName}</div>
         </div>
-        <div className="flex flex-col items-center sm:flex-row sm:justify-start">
-          <h4 className="text-text-primary me-2 font-bold">Balance:</h4>
-          <div>
+        <div className="flex flex-col space-y-1">
+          <div className="flex flex-col items-center sm:flex-row sm:items-center">
+            <h4 className="text-text-primary me-2 font-bold">Balance:</h4>
             <span className="font-semibold text-[var(--accent-green)]">
               {currentBalance?.matureDisplay} KAS
+            </span>
+          </div>
+          <div className="flex flex-col items-center sm:flex-row sm:items-center">
+            <h5 className="text-text-primary me-2 text-sm font-bold">
+              Pending:
+            </h5>
+            <span className="text-base font-semibold text-[var(--accent-green)]">
+              {currentBalance?.pendingDisplay} KAS
+            </span>
+          </div>
+          <div className="flex flex-col items-center sm:flex-row sm:items-center">
+            <h5 className="text-text-primary me-2 text-sm font-bold">
+              Outgoing:
+            </h5>
+            <span className="text-base font-semibold text-[var(--accent-green)]">
+              {currentBalance?.outgoingDisplay} KAS
             </span>
           </div>
         </div>

--- a/src/components/Modals/WalletInfo.tsx
+++ b/src/components/Modals/WalletInfo.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useWalletStore } from "../../store/wallet.store";
 import { UtxoCompound } from "./UtxoCompound";
+import { BALANCE_WARN } from "../../config/constants";
 
 type FrozenBalance = {
   matureUtxoCount: number;
@@ -25,7 +26,6 @@ export const WalletInfo = () => {
         matureDisplay: frozenBalance.matureDisplay,
       }
     : walletBalance;
-
   return (
     <div className="m-2 sm:m-4">
       <div className="border-kas-secondary bg-kas-secondary/5 mb-4 rounded-2xl border p-4">
@@ -33,7 +33,7 @@ export const WalletInfo = () => {
           <h4 className="text-text-primary me-2 font-bold">Wallet Name:</h4>
           <div className="text-base font-semibold">{unlockedWalletName}</div>
         </div>
-        <div className="flex flex-col space-y-1">
+        <div className="mb-2 flex flex-col space-y-1">
           <div className="flex flex-col items-center sm:flex-row sm:items-center">
             <h4 className="text-text-primary me-2 font-bold">Balance:</h4>
             <span className="font-semibold text-[var(--accent-green)]">
@@ -57,6 +57,13 @@ export const WalletInfo = () => {
             </span>
           </div>
         </div>
+        {(currentBalance?.mature ?? 0) > BALANCE_WARN && (
+          <span className="text-text-secondary text-center text-sm font-semibold sm:text-start">
+            <p>That's a lot of KAS!</p>
+            <p>Consider withdrawing some to cold storage. </p>
+            <p>Remember, Kasia is a messaging app!</p>
+          </span>
+        )}
       </div>
 
       {((currentBalance?.matureUtxoCount ?? 0) > 0 ||

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -22,6 +22,10 @@ export const MAX_PAYLOAD_SIZE = 17.7 * 1024;
 // rough (heuristic) for char limit on messages
 export const MAX_CHAT_INPUT_CHAR = 18000;
 
+// Triggers a warn in the wallet to withdraw to cold storage.
+// Settings at 30KAS
+export const BALANCE_WARN = BigInt(30 * 100_000_000);
+
 export const DEFAULT_FEE_BUCKETS: FeeBucket[] = [
   {
     label: "Low",

--- a/src/service/account-service.ts
+++ b/src/service/account-service.ts
@@ -11,6 +11,7 @@ import {
   kaspaToSompi,
   ITransactionOutput,
   PrivateKeyGenerator,
+  Generator,
 } from "kaspa-wasm";
 import { KaspaClient } from "./kaspa-client";
 import {
@@ -365,6 +366,33 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
         `Fee cannot exceed ${Number(MAX_TX_FEE) / 100_000_000} KAS`
       );
     }
+  }
+
+  private async processGeneratorTransactions(
+    generator: Generator,
+    postTransactionCallback?: () => Promise<void>
+  ): Promise<string> {
+    const privateKeyGenerator = WalletStorageService.getPrivateKeyGenerator(
+      this.unlockedWallet,
+      this.pwd
+    );
+
+    if (!privateKeyGenerator) {
+      throw new Error("Failed to generate private key");
+    }
+
+    let pending: PendingTransaction | null;
+    while ((pending = await generator.next())) {
+      const txid = await this.signAndSubmitTransaction(
+        pending,
+        privateKeyGenerator
+      );
+      if (postTransactionCallback) {
+        await postTransactionCallback();
+      }
+      return txid;
+    }
+    throw new Error("Failed to generate transaction");
   }
 
   private async signAndSubmitTransaction(
@@ -736,17 +764,7 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
     );
     console.log(`Payload length: ${transaction.payload.length / 2} bytes`);
 
-    const privateKeyGenerator = WalletStorageService.getPrivateKeyGenerator(
-      this.unlockedWallet,
-      this.pwd
-    );
-
-    if (!privateKeyGenerator) {
-      throw new Error("Failed to generate private key");
-    }
-
     try {
-      // Use our optimized generator creation method
       const generator = TransactionGeneratorService.createForTransaction({
         context: this.ctx,
         networkId: this.networkId,
@@ -758,15 +776,7 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
       });
 
       console.log("Generating transaction...");
-      let pending: PendingTransaction | null;
-      while ((pending = await generator.next())) {
-        const txid = await this.signAndSubmitTransaction(
-          pending,
-          privateKeyGenerator
-        );
-        return txid;
-      }
-      throw new Error("Failed to generate transaction");
+      return this.processGeneratorTransactions(generator);
     } catch (error) {
       console.error("Error creating transaction:", error);
       throw error;
@@ -782,14 +792,7 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
     if (!paymentTransaction.amount)
       throw new Error("Transaction amount is required");
 
-    const privateKeyGenerator = WalletStorageService.getPrivateKeyGenerator(
-      this.unlockedWallet,
-      this.pwd
-    );
-    if (!privateKeyGenerator) throw new Error("Failed to generate private key");
-
     try {
-      // added boolean type to prevent full assignment
       const rawMature = this.ctx.balance?.mature ?? 0n;
       const isFullBalance: boolean = rawMature === paymentTransaction.amount;
 
@@ -804,16 +807,11 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
         isFullBalance,
       });
 
-      let pending: PendingTransaction | null;
-      while ((pending = await generator.next())) {
-        const txid = await this.signAndSubmitTransaction(
-          pending,
-          privateKeyGenerator
-        );
-        if (isFullBalance) await this.retrackAfterFullSend();
-        return txid;
-      }
-      throw new Error("Failed to generate transaction");
+      const postCallback = isFullBalance
+        ? () => this.retrackAfterFullSend()
+        : undefined;
+
+      return this.processGeneratorTransactions(generator, postCallback);
     } catch (error) {
       console.error("Error creating payment with message:", error);
       throw error;
@@ -829,14 +827,7 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
     if (!withdrawTransaction.amount)
       throw new Error("Transaction amount is required");
 
-    const privateKeyGenerator = WalletStorageService.getPrivateKeyGenerator(
-      this.unlockedWallet,
-      this.pwd
-    );
-    if (!privateKeyGenerator) throw new Error("Failed to generate private key");
-
     try {
-      // added boolean type to prevent full assignment
       const rawMature = this.ctx.balance?.mature ?? 0n;
       const isFullBalance: boolean = rawMature === withdrawTransaction.amount;
 
@@ -850,16 +841,11 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
         isFullBalance,
       });
 
-      let pending: PendingTransaction | null;
-      while ((pending = await generator.next())) {
-        const txid = await this.signAndSubmitTransaction(
-          pending,
-          privateKeyGenerator
-        );
-        if (isFullBalance) await this.retrackAfterFullSend();
-        return txid;
-      }
-      throw new Error("Failed to generate transaction");
+      const postCallback = isFullBalance
+        ? () => this.retrackAfterFullSend()
+        : undefined;
+
+      return this.processGeneratorTransactions(generator, postCallback);
     } catch (error) {
       console.error("Error creating transaction:", error);
       throw error;
@@ -871,37 +857,19 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
 
     console.log("Consolidating all UTXOs to:", this.recv.toString());
 
-    const privateKeyGenerator = WalletStorageService.getPrivateKeyGenerator(
-      this.unlockedWallet,
-      this.pwd
-    );
-
-    if (!privateKeyGenerator) {
-      throw new Error("Failed to generate private key");
-    }
-
     try {
       const matureBalance = this.ctx.balance?.mature;
       if (!matureBalance || matureBalance === 0n) {
         throw new Error("No mature UTXOs available for compound transaction");
       }
 
-      // Use our simple compound transaction generator
       const generator = TransactionGeneratorService.createForCompound({
         context: this.ctx,
         networkId: this.networkId,
         receiveAddress: this.recv,
       });
 
-      let pending: PendingTransaction | null;
-      while ((pending = await generator.next())) {
-        const txid = await this.signAndSubmitTransaction(
-          pending,
-          privateKeyGenerator
-        );
-        return txid;
-      }
-      throw new Error("Failed to generate transaction");
+      return this.processGeneratorTransactions(generator);
     } catch (error) {
       console.error("Error creating compound transaction:", error);
       throw error;

--- a/src/service/account-service.ts
+++ b/src/service/account-service.ts
@@ -758,21 +758,15 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
       });
 
       console.log("Generating transaction...");
-      const pendingTransaction: PendingTransaction | null =
-        await generator.next();
-
-      if (!pendingTransaction) {
-        throw new Error("Failed to generate transaction");
+      let pending: PendingTransaction | null;
+      while ((pending = await generator.next())) {
+        const txid = await this.signAndSubmitTransaction(
+          pending,
+          privateKeyGenerator
+        );
+        return txid;
       }
-
-      if ((await generator.next()) !== null) {
-        throw new Error("Unexpected multiple transaction generation");
-      }
-
-      return this.signAndSubmitTransaction(
-        pendingTransaction,
-        privateKeyGenerator
-      );
+      throw new Error("Failed to generate transaction");
     } catch (error) {
       console.error("Error creating transaction:", error);
       throw error;
@@ -810,17 +804,16 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
         isFullBalance,
       });
 
-      const pendingTransaction: PendingTransaction | null =
-        await generator.next();
-      if (!pendingTransaction)
-        throw new Error("Failed to generate transaction");
-
-      const txid = await this.signAndSubmitTransaction(
-        pendingTransaction,
-        privateKeyGenerator
-      );
-      if (isFullBalance) await this.retrackAfterFullSend();
-      return txid;
+      let pending: PendingTransaction | null;
+      while ((pending = await generator.next())) {
+        const txid = await this.signAndSubmitTransaction(
+          pending,
+          privateKeyGenerator
+        );
+        if (isFullBalance) await this.retrackAfterFullSend();
+        return txid;
+      }
+      throw new Error("Failed to generate transaction");
     } catch (error) {
       console.error("Error creating payment with message:", error);
       throw error;
@@ -900,18 +893,15 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
         receiveAddress: this.recv,
       });
 
-      const pendingTransaction: PendingTransaction | null =
-        await generator.next();
-
-      if (!pendingTransaction) {
-        throw new Error("Failed to generate transaction");
+      let pending: PendingTransaction | null;
+      while ((pending = await generator.next())) {
+        const txid = await this.signAndSubmitTransaction(
+          pending,
+          privateKeyGenerator
+        );
+        return txid;
       }
-
-      // Sign the transaction
-      return this.signAndSubmitTransaction(
-        pendingTransaction,
-        privateKeyGenerator
-      );
+      throw new Error("Failed to generate transaction");
     } catch (error) {
       console.error("Error creating compound transaction:", error);
       throw error;

--- a/src/service/account-service.ts
+++ b/src/service/account-service.ts
@@ -207,6 +207,20 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
     });
   }
 
+  // this is a hacky approach needed to clear context and retract
+  // should only be used after emptying the full wallet
+  // we use this because generator / wasm doesn't have a graceful and clean solution
+  private async retrackAfterFullSend() {
+    if (!this.processor || !this.recv) return;
+    try {
+      this.context.free();
+    } catch (error) {
+      console.error("Error in retrackAfterFullSend:", error);
+    }
+    this.context = new UtxoContext({ processor: this.processor });
+    await this.context.trackAddresses([this.recv]);
+  }
+
   // Add method to set password
   public setPassword(password: string) {
     if (!password) {
@@ -769,28 +783,22 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
     paymentTransaction: CreatePaymentWithMessageArgs
   ): Promise<TransactionId> {
     this.assertReady();
-
-    if (!paymentTransaction.address) {
+    if (!paymentTransaction.address)
       throw new Error("Transaction address is required");
-    }
-
-    if (!paymentTransaction.amount) {
+    if (!paymentTransaction.amount)
       throw new Error("Transaction amount is required");
-    }
 
     const privateKeyGenerator = WalletStorageService.getPrivateKeyGenerator(
       this.unlockedWallet,
       this.pwd
     );
-
-    if (!privateKeyGenerator) {
-      throw new Error("Failed to generate private key");
-    }
+    if (!privateKeyGenerator) throw new Error("Failed to generate private key");
 
     try {
-      const matureBalance = this.ctx.balance?.mature ?? 0n;
-      const isFullBalance = matureBalance === paymentTransaction.amount;
-      // Use a modified generator that sends to recipient but includes payload
+      // added boolean type to prevent full assignment
+      const rawMature = this.ctx.balance?.mature ?? 0n;
+      const isFullBalance: boolean = rawMature === paymentTransaction.amount;
+
       const generator = TransactionGeneratorService.createForPaymentOrWithdraw({
         context: this.ctx,
         networkId: this.networkId,
@@ -804,20 +812,15 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
 
       const pendingTransaction: PendingTransaction | null =
         await generator.next();
-
-      if (!pendingTransaction) {
+      if (!pendingTransaction)
         throw new Error("Failed to generate transaction");
-      }
 
-      if ((await generator.next()) !== null) {
-        throw new Error("Unexpected multiple transaction generation");
-      }
-
-      // Sign and send the transaction
-      return this.signAndSubmitTransaction(
+      const txid = await this.signAndSubmitTransaction(
         pendingTransaction,
         privateKeyGenerator
       );
+      if (isFullBalance) await this.retrackAfterFullSend();
+      return txid;
     } catch (error) {
       console.error("Error creating payment with message:", error);
       throw error;
@@ -828,28 +831,22 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
     withdrawTransaction: CreateWithdrawTransactionArgs
   ) {
     this.assertReady();
-
-    if (!withdrawTransaction.address) {
+    if (!withdrawTransaction.address)
       throw new Error("Transaction address is required");
-    }
-
-    if (!withdrawTransaction.amount) {
+    if (!withdrawTransaction.amount)
       throw new Error("Transaction amount is required");
-    }
 
     const privateKeyGenerator = WalletStorageService.getPrivateKeyGenerator(
       this.unlockedWallet,
       this.pwd
     );
-
-    if (!privateKeyGenerator) {
-      throw new Error("Failed to generate private key");
-    }
+    if (!privateKeyGenerator) throw new Error("Failed to generate private key");
 
     try {
-      const matureBalance = this.ctx.balance?.mature;
-      const isFullBalance = matureBalance === withdrawTransaction.amount;
-      // Use our optimized generator creation method
+      // added boolean type to prevent full assignment
+      const rawMature = this.ctx.balance?.mature ?? 0n;
+      const isFullBalance: boolean = rawMature === withdrawTransaction.amount;
+
       const generator = TransactionGeneratorService.createForPaymentOrWithdraw({
         context: this.ctx,
         networkId: this.networkId,
@@ -857,21 +854,19 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
         destinationAddress: withdrawTransaction.address,
         amount: withdrawTransaction.amount,
         priorityFee: withdrawTransaction.priorityFee,
-        isFullBalance: isFullBalance,
+        isFullBalance,
       });
 
-      const pendingTransaction: PendingTransaction | null =
-        await generator.next();
-
-      if (!pendingTransaction) {
-        throw new Error("Failed to generate transaction");
+      let pending: PendingTransaction | null;
+      while ((pending = await generator.next())) {
+        const txid = await this.signAndSubmitTransaction(
+          pending,
+          privateKeyGenerator
+        );
+        if (isFullBalance) await this.retrackAfterFullSend();
+        return txid;
       }
-
-      // Sign and send the transaction
-      return this.signAndSubmitTransaction(
-        pendingTransaction,
-        privateKeyGenerator
-      );
+      throw new Error("Failed to generate transaction");
     } catch (error) {
       console.error("Error creating transaction:", error);
       throw error;

--- a/src/service/transaction-generator.ts
+++ b/src/service/transaction-generator.ts
@@ -104,7 +104,6 @@ export class TransactionGeneratorService {
 
     return new Generator(settings);
   }
-
   /**
    * Create generator for payment and withdrawal transactions
    */


### PR DESCRIPTION
## what?

currently the utxocontext + generator don’t gracefully handle sending all funds.

i assume that: with a changeaddress but no actual change, utxocontext never settles and leaves stale `outgoing`. the transfer succeeds, but the context stays wrong.

we tried:

```
context.clear();
context.trackAddresses([this.recv]);
```

after send, but it races balance events and can leave spent funds in `mature`.

what i've settled on is:
after a successful full-balance send, use a new function `retrackAfterFullSend`, which frees the current conteext, then swaps in a fresh utxocontext and re-track the primary address.

seems to work?

also i 
- re added the display types to the wallet (pending, outgoing.
- refactored the processing of generators
- added a warning to withdraw to cold wallet if balance over 30KAS

see handy flow chart of how this all flows:
<img width="2571" height="3840" alt="TxFlow Mermaid Chart-2025-08-23-0101518" src="https://github.com/user-attachments/assets/ef7d2513-be0b-4a53-9662-76e1f9279cc9" />
