### PR TITLE
feat: bip39 passphrase

### DIFF
--- a/src/components/MnemonicEntry.tsx
+++ b/src/components/MnemonicEntry.tsx
@@ -1,16 +1,20 @@
 import React, { useState, ClipboardEvent, ChangeEvent, useEffect } from "react";
+import { Switch } from "@headlessui/react";
 import clsx from "clsx";
 
 interface MnemonicEntryProps {
   seedPhraseLength: number;
   onMnemonicChange: (mnemonic: string) => void;
+  passphraseRef?: React.RefObject<HTMLInputElement | null>;
 }
 
 export const MnemonicEntry = ({
   seedPhraseLength,
   onMnemonicChange,
+  passphraseRef,
 }: MnemonicEntryProps) => {
   const [focusedIndex, setFocusedIndex] = useState<number | null>(null);
+  const [showPassphrase, setShowPassphrase] = useState(false);
 
   // If the user changes the seed phrase length, reset the input fields
   useEffect(() => {
@@ -75,6 +79,63 @@ export const MnemonicEntry = ({
           );
         })}
       </div>
+
+      <div className="mt-4 mb-4">
+        <label className="flex items-center gap-3 text-sm">
+          <Switch
+            checked={showPassphrase}
+            onChange={setShowPassphrase}
+            className={clsx(
+              "relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:ring-2 focus:ring-[var(--color-kas-secondary)] focus:ring-offset-2 focus:outline-none",
+              {
+                "bg-[var(--color-kas-secondary)]": showPassphrase,
+                "bg-[var(--primary-border)]": !showPassphrase,
+              }
+            )}
+          >
+            <span
+              className={clsx(
+                "inline-block h-4 w-4 transform rounded-full bg-white transition-transform",
+                {
+                  "translate-x-6": showPassphrase,
+                  "translate-x-1": !showPassphrase,
+                }
+              )}
+            />
+          </Switch>
+          <span className="text-[var(--text-secondary)]">
+            My wallet has a passphrase (BIP39)
+          </span>
+        </label>
+        <p className="mt-1 text-xs text-[var(--text-secondary)]">
+          Check this box if your wallet was created with an additional
+          passphrase for extra security.
+        </p>
+      </div>
+
+      {showPassphrase && (
+        <div className="mt-4 mb-4">
+          <label className="mb-3 block text-base font-semibold text-[var(--text-primary)]">
+            Passphrase (Optional)
+          </label>
+          <input
+            ref={passphraseRef}
+            type="password"
+            placeholder="Enter passphrase (leave empty if none)"
+            className={clsx(
+              "w-full rounded-xl p-2",
+              "border-primary-border border bg-[var(--primary-bg)]",
+              "text-[var(--text-primary)]",
+              "focus:border-[var(--color-kas-secondary)] focus:outline-none",
+              "placeholder:text-sm"
+            )}
+          />
+          <p className="mt-3 text-xs text-[var(--text-secondary)]">
+            A passphrase adds an extra layer of security to your wallet. Only
+            enter one if your wallet was created with a passphrase.
+          </p>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/Modals/WalletSeedRetreiveDisplay.tsx
+++ b/src/components/Modals/WalletSeedRetreiveDisplay.tsx
@@ -2,7 +2,7 @@ import { FC, useEffect, useState } from "react";
 import { decryptXChaCha20Poly1305 } from "kaspa-wasm";
 import { useWalletStore } from "../../store/wallet.store";
 import { StoredWallet } from "../../types/wallet.type";
-import { Eye, EyeOff } from "lucide-react";
+import { Eye, EyeOff, AlertTriangle } from "lucide-react";
 import clsx from "clsx";
 import { Button } from "../Common/Button";
 import { toast } from "../../utils/toast-helper";
@@ -13,6 +13,7 @@ export const WalletSeedRetreiveDisplay: FC = () => {
   const [showSeedPhrase, setShowSeedPhrase] = useState(false);
   const [seedPhrase, setSeedPhrase] = useState("");
   const [isBlurred, setIsBlurred] = useState(true);
+  const [hasPassphrase, setHasPassphrase] = useState(false);
   const selectedWalletId = useWalletStore((state) => state.selectedWalletId);
   const [blurTimeout, setBlurTimeout] = useState<NodeJS.Timeout | null>(null);
 
@@ -66,6 +67,9 @@ export const WalletSeedRetreiveDisplay: FC = () => {
         toast.error("Wallet not found");
         return;
       }
+
+      // Check if wallet has a passphrase
+      setHasPassphrase(!!foundStoredWallet.encryptedPassphrase);
 
       // Decrypt the seed phrase
       const phrase = decryptXChaCha20Poly1305(
@@ -129,6 +133,20 @@ export const WalletSeedRetreiveDisplay: FC = () => {
           <p className="mb-2 p-2 text-center font-semibold">
             Your seed phrase:
           </p>
+          {hasPassphrase && (
+            <div className="mb-2 flex items-center gap-3 rounded-lg border border-[var(--accent-yellow)] bg-[var(--secondary-bg)] p-3 text-sm">
+              <AlertTriangle className="h-5 w-5 flex-shrink-0 text-[var(--text-warning)]" />
+              <div className="text-left">
+                <div className="text-[var(--text-warning)]">
+                  <strong>Important:</strong> This wallet was created with a
+                  BIP39 passphrase.
+                  <br />
+                  You'll need both the seed phrase AND the passphrase to recover
+                  this wallet elsewhere.
+                </div>
+              </div>
+            </div>
+          )}
           <div
             className={clsx(
               "word-break border-primary-border bg-primary-bg mb-4 rounded-3xl border px-4 py-3 font-mono break-all",
@@ -167,6 +185,7 @@ export const WalletSeedRetreiveDisplay: FC = () => {
                 setSeedPhrase("");
                 setPassword("");
                 setIsBlurred(true);
+                setHasPassphrase(false);
               }}
               variant="secondary"
               className="px-3 py-2 shadow"

--- a/src/components/WalletLockedFlow/Create.tsx
+++ b/src/components/WalletLockedFlow/Create.tsx
@@ -53,7 +53,8 @@ export const CreateWallet = ({ onSuccess, onBack }: CreateWalletProps) => {
         nameRef.current.value,
         mnemonic,
         pw,
-        derivationType
+        derivationType,
+        undefined
       );
       onSuccess(id, mnemonic);
     } catch (err) {

--- a/src/components/WalletLockedFlow/Import.tsx
+++ b/src/components/WalletLockedFlow/Import.tsx
@@ -25,6 +25,7 @@ export const Import = ({ onSuccess, onBack }: ImportWalletProps) => {
 
   const passwordRef = useRef<HTMLInputElement>(null);
   const nameRef = useRef<HTMLInputElement>(null);
+  const passphraseRef = useRef<HTMLInputElement>(null);
 
   const { createWallet } = useWalletStore();
 
@@ -44,12 +45,20 @@ export const Import = ({ onSuccess, onBack }: ImportWalletProps) => {
     }
     try {
       const mnemonic = new Mnemonic(mnemonicValue);
-      await createWallet(nameRef.current.value, mnemonic, pw, derivationType);
+      const passphrase = passphraseRef.current?.value || undefined;
+      await createWallet(
+        nameRef.current.value,
+        mnemonic,
+        pw,
+        derivationType,
+        passphrase
+      );
       onSuccess();
     } catch (err) {
       setError(err instanceof Error ? err.message : "Invalid mnemonic");
     } finally {
       setMnemonicValue("");
+      if (passphraseRef.current?.value) passphraseRef.current.value = "";
       if (passwordRef.current?.value) passwordRef.current.value = "";
     }
   };
@@ -144,6 +153,7 @@ export const Import = ({ onSuccess, onBack }: ImportWalletProps) => {
       <MnemonicEntry
         seedPhraseLength={seedPhraseLength}
         onMnemonicChange={setMnemonicValue}
+        passphraseRef={passphraseRef}
       />
 
       <div className="mb-6">

--- a/src/service/wallet-storage-service.ts
+++ b/src/service/wallet-storage-service.ts
@@ -135,12 +135,23 @@ export class WalletStorageService {
 
     try {
       // First decrypt the mnemonic phrase
-      const mnemonic = new Mnemonic(
-        decryptXChaCha20Poly1305(wallet.encryptedPhrase, password)
+      const mnemonicPhrase = decryptXChaCha20Poly1305(
+        wallet.encryptedPhrase,
+        password
       );
+      const mnemonic = new Mnemonic(mnemonicPhrase);
 
-      // Generate the seed and extended private key
-      const seed = mnemonic.toSeed();
+      // Decrypt passphrase if it exists
+      let passphrase = "";
+      if (wallet.encryptedPassphrase) {
+        passphrase = decryptXChaCha20Poly1305(
+          wallet.encryptedPassphrase,
+          password
+        );
+      }
+
+      // Generate the seed with passphrase and extended private key
+      const seed = mnemonic.toSeed(passphrase);
       const extendedKey = new XPrv(seed);
 
       // Determine derivation type (default to legacy for existing wallets)
@@ -167,6 +178,7 @@ export class WalletStorageService {
         password,
         derivationType,
         receivePublicKey,
+        passphrase: passphrase || undefined,
       };
     } catch (error) {
       console.error("Error decrypting wallet:", error);
@@ -178,7 +190,8 @@ export class WalletStorageService {
     name: string,
     mnemonic: Mnemonic,
     password: string,
-    derivationType: WalletDerivationType = "standard"
+    derivationType: WalletDerivationType = "standard",
+    passphrase?: string
   ): string {
     const walletsString = localStorage.getItem(this._storageKey);
     if (!walletsString) throw new Error("Storage not initialized");
@@ -192,6 +205,9 @@ export class WalletStorageService {
       createdAt: new Date().toISOString(),
       accounts: [{ name: "Account 1" }],
       derivationType, // New wallets default to standard
+      encryptedPassphrase: passphrase
+        ? encryptXChaCha20Poly1305(passphrase, password)
+        : undefined,
     };
 
     wallets.push(newWallet);
@@ -246,9 +262,24 @@ export class WalletStorageService {
       );
       const mnemonic = new Mnemonic(mnemonicPhrase);
 
-      // Create new wallet with standard derivation
+      // Decrypt passphrase if it exists
+      let passphrase = "";
+      if (wallet.encryptedPassphrase) {
+        passphrase = decryptXChaCha20Poly1305(
+          wallet.encryptedPassphrase,
+          password
+        );
+      }
+
+      // Create new wallet with standard derivation, preserving passphrase
       const migrationName = newName || `${wallet.name} (Standard)`;
-      return this.create(migrationName, mnemonic, password, "standard");
+      return this.create(
+        migrationName,
+        mnemonic,
+        password,
+        "standard",
+        passphrase || undefined
+      );
     } catch (error) {
       console.error("Error migrating wallet:", error);
       throw new Error("Failed to migrate wallet");
@@ -288,11 +319,25 @@ export class WalletStorageService {
         newPassword
       );
 
-      // Create a copy of wallets and update the encrypted phrase
+      // Handle passphrase re-encryption if it exists
+      let newEncryptedPassphrase = wallet.encryptedPassphrase;
+      if (wallet.encryptedPassphrase) {
+        const passphrase = decryptXChaCha20Poly1305(
+          wallet.encryptedPassphrase,
+          currentPassword
+        );
+        newEncryptedPassphrase = encryptXChaCha20Poly1305(
+          passphrase,
+          newPassword
+        );
+      }
+
+      // Create a copy of wallets and update the encrypted phrase and passphrase
       const updatedWallets = [...wallets];
       updatedWallets[walletIndex] = {
         ...wallet,
         encryptedPhrase: newEncryptedPhrase,
+        encryptedPassphrase: newEncryptedPassphrase,
       };
 
       // Save to localStorage first - if this fails, original state is preserved

--- a/src/store/wallet.store.ts
+++ b/src/store/wallet.store.ts
@@ -79,7 +79,8 @@ type WalletState = {
     name: string,
     mnemonic: Mnemonic,
     password: string,
-    derivationType?: WalletDerivationType
+    derivationType?: WalletDerivationType,
+    passphrase?: string
   ) => Promise<string>;
   deleteWallet: (walletId: string) => void;
   unlock: (walletId: string, password: string) => Promise<UnlockedWallet>;
@@ -174,13 +175,15 @@ export const useWalletStore = create<WalletState>((set, get) => {
       name: string,
       mnemonic: Mnemonic,
       password: string,
-      derivationType?: WalletDerivationType
+      derivationType?: WalletDerivationType,
+      passphrase?: string
     ) => {
       const walletId = _walletStorage.create(
         name,
         mnemonic,
         password,
-        derivationType
+        derivationType,
+        passphrase
       );
       get().loadWallets();
       return walletId;

--- a/src/types/wallet.type.ts
+++ b/src/types/wallet.type.ts
@@ -19,6 +19,7 @@ export type UnlockedWallet = {
   receivePublicKey: PublicKey;
   // Add derivation type to unlocked wallet
   derivationType: WalletDerivationType;
+  passphrase?: string;
 };
 
 export type StoredWallet = {
@@ -29,6 +30,7 @@ export type StoredWallet = {
   accounts: { name: string }[];
   // Add derivation type to track wallet standard
   derivationType?: WalletDerivationType; // Optional for backward compatibility
+  encryptedPassphrase?: string;
 };
 
 export type WalletBalance = {


### PR DESCRIPTION
## what?

- re applies this proposed [PR](https://github.com/K-Kluster/Kasia/pull/163) to the new code base.
- proposal is allowing wallet imports to **import (only)** with a 25th / 13th passphrase as[ bip39 spec](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki#from-mnemonic-to-seed)
- i added reminder to wallet export that there is a passphrase (does not reveal it).

<img width="723" height="550" alt="image" src="https://github.com/user-attachments/assets/8a777911-01cc-4a07-bea8-cbaaac7be669" />

<img width="724" height="530" alt="image" src="https://github.com/user-attachments/assets/27ce3f56-edca-44ac-a9dc-20f1730f22ba" />

