### PR TITLE
fix: routing to wallet diretly causes no wallet selection

### DIFF
--- a/src/containers/WalletLockedFlowContainer.tsx
+++ b/src/containers/WalletLockedFlowContainer.tsx
@@ -70,6 +70,13 @@ export const WalletLockedFlowContainer = ({
     loadWallets();
   }, [loadWallets]);
 
+  // select wallet from URL parameter when component mounts, needed if user routes to unlock screen
+  useEffect(() => {
+    if (wallet && !selectedWalletId) {
+      selectWallet(wallet);
+    }
+  }, [wallet, selectedWalletId, selectWallet]);
+
   // ref for scroll up when step changes, like a page reset
   const containerRef = useRef<HTMLDivElement>(null);
 


### PR DESCRIPTION
## what?

routing to wallet id directly currently does not select wallet id to unlock.
this fixes it.

_note: maybe it was an issue with the new branch only. but I didn't confirm - this fixes it regardless._