### PR TITLE
refactor(style) + fix some things

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .rules
-
+.cargo
 wasm/*
 
 # Logs

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover"
+      content="width=device-width, initial-scale=1.0, viewport-fit=cover"
     />
     <link rel="icon" type="image/png" href="/kasia-logo.png" />
     <link rel="stylesheet" href="/src/index.css" />
@@ -48,6 +48,7 @@
 
   <body>
     <div id="root"></div>
+
     <script>
       // Adds a CSS var '--kb' with the keyboard height (best-effort)
       (function () {
@@ -64,6 +65,16 @@
         window.addEventListener("orientationchange", setKb);
         setKb();
       })();
+
+      // prevent double tap and pinch zooming
+      // we do set `touch-action: manipulation;` in css, but need this as fallback for other browsers (ios etc)
+      document.addEventListener(
+        "gesturestart",
+        function (e) {
+          e.preventDefault();
+        },
+        { passive: false }
+      );
     </script>
     <script type="module" src="/src/init.ts"></script>
   </body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,9 @@
         "@tauri-apps/plugin-barcode-scanner": "^2.4.0",
         "@tauri-apps/plugin-biometry": "./vendors/tauri-plugin-biometry",
         "@tauri-apps/plugin-clipboard-manager": "^2.3.0",
+        "@tauri-apps/plugin-opener": "^2.5.0",
         "@tauri-apps/plugin-os": "^2.3.1",
+        "@tauri-apps/plugin-shell": "^2.3.1",
         "cipher": "file:cipher-wasm",
         "clsx": "2.1.1",
         "eventemitter3": "5.0.1",
@@ -44,7 +46,6 @@
         "@vitest/browser": "^3.2.4",
         "autoprefixer": "^10.4.21",
         "babel-plugin-react-compiler": "^19.1.0-rc.2",
-        "cross-env": "^10.0.0",
         "cssnano": "^7.0.7",
         "eslint": "^9.21.0",
         "eslint-plugin-react-hooks": "^6.0.0-rc.1",
@@ -2791,13 +2792,6 @@
         "postcss": "^8.4"
       }
     },
-    "node_modules/@epic-web/invariant": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
-      "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.6",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.6.tgz",
@@ -5222,10 +5216,28 @@
         "@tauri-apps/api": "^2.6.0"
       }
     },
+    "node_modules/@tauri-apps/plugin-opener": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-opener/-/plugin-opener-2.5.0.tgz",
+      "integrity": "sha512-B0LShOYae4CZjN8leiNDbnfjSrTwoZakqKaWpfoH6nXiJwt6Rgj6RnVIffG3DoJiKsffRhMkjmBV9VeilSb4TA==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.8.0"
+      }
+    },
     "node_modules/@tauri-apps/plugin-os": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-os/-/plugin-os-2.3.1.tgz",
       "integrity": "sha512-ty5V8XDUIFbSnrk3zsFoP3kzN+vAufYzalJSlmrVhQTImIZa1aL1a03bOaP2vuBvfR+WDRC6NgV2xBl8G07d+w==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.8.0"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-shell": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-shell/-/plugin-shell-2.3.1.tgz",
+      "integrity": "sha512-jjs2WGDO/9z2pjNlydY/F5yYhNsscv99K5lCmU5uKjsVvQ3dRlDhhtVYoa4OLDmktLtQvgvbQjCFibMl6tgGfw==",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@tauri-apps/api": "^2.8.0"
@@ -6603,24 +6615,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
-      }
-    },
-    "node_modules/cross-env": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.0.0.tgz",
-      "integrity": "sha512-aU8qlEK/nHYtVuN4p7UQgAwVljzMg8hB4YK5ThRqD2l/ziSnryncPNn7bMLt5cFYsKVKBh8HqLqyCoTupEUu7Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@epic-web/invariant": "^1.0.0",
-        "cross-spawn": "^7.0.6"
-      },
-      "bin": {
-        "cross-env": "dist/bin/cross-env.js",
-        "cross-env-shell": "dist/bin/cross-env-shell.js"
-      },
-      "engines": {
-        "node": ">=20"
       }
     },
     "node_modules/cross-spawn": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kasia",
   "private": true,
-  "version": "0.5.5",
+  "version": "0.6.0",
   "type": "module",
   "scripts": {
     "dev": "node scripts/run-vite-with-env.cjs dev",
@@ -29,6 +29,7 @@
     "@tauri-apps/plugin-barcode-scanner": "^2.4.0",
     "@tauri-apps/plugin-biometry": "./vendors/tauri-plugin-biometry",
     "@tauri-apps/plugin-clipboard-manager": "^2.3.0",
+    "@tauri-apps/plugin-opener": "^2.5.0",
     "@tauri-apps/plugin-os": "^2.3.1",
     "cipher": "file:cipher-wasm",
     "clsx": "2.1.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -92,7 +92,7 @@ checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "app"
-version = "0.5.5"
+version = "0.6.0"
 dependencies = [
  "log",
  "rand 0.9.2",
@@ -105,6 +105,7 @@ dependencies = [
  "tauri-plugin-biometry",
  "tauri-plugin-clipboard-manager",
  "tauri-plugin-log",
+ "tauri-plugin-opener",
  "tauri-plugin-os",
  "tokio",
 ]
@@ -137,6 +138,137 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "497c00e0fd83a72a79a39fcbd8e3e2f055d6f6c7e025f3b3d91f4f8e76527fb8"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix 1.0.8",
+ "slab",
+ "windows-sys 0.61.1",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd03604047cee9b6ce9de9f70c6cd540a0520c813cbd49bae61f33ab80ed1dc"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix 1.0.8",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43c070bbf59cd3570b6b2dd54cd772527c7c3620fce8be898406dd3ed6adc64c"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix 1.0.8",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.1",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "atk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -158,6 +290,12 @@ dependencies = [
  "libc",
  "system-deps",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
@@ -244,6 +382,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "340d2f0bdb2a43c1d3cd40513185b2bd7def0aa1052f956455114bc98f82dcf2"
 dependencies = [
  "objc2 0.6.1",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -481,7 +632,7 @@ dependencies = [
  "iana-time-zone",
  "num-traits",
  "serde",
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -501,6 +652,15 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -847,6 +1007,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
 
 [[package]]
+name = "endi"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3d8a32ae18130a3c84dd492d4215c3d913c3b07c6b63c2eb3eb7ff1101ab7bf"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "env_filter"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -887,6 +1074,27 @@ name = "error-code"
 version = "3.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "fastrand"
@@ -1047,6 +1255,19 @@ name = "futures-io"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -1442,6 +1663,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1759,6 +1986,25 @@ checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
 dependencies = [
  "memchr",
  "serde",
+]
+
+[[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
 ]
 
 [[package]]
@@ -2113,6 +2359,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.9.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
 name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2442,10 +2701,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "open"
+version = "5.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2483562e62ea94312f3576a7aca397306df7990b8d89033e18766744377ef95"
+dependencies = [
+ "dunce",
+ "is-wsl",
+ "libc",
+ "pathdiff",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "os_info"
@@ -2495,6 +2776,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2516,6 +2803,12 @@ dependencies = [
  "smallvec",
  "windows-targets 0.52.6",
 ]
+
+[[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "percent-encoding"
@@ -2680,6 +2973,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "piper"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2722,6 +3026,20 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix 1.0.8",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -3476,6 +3794,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3584,6 +3911,12 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "string_cache"
@@ -3967,6 +4300,28 @@ dependencies = [
  "tauri-plugin",
  "thiserror 2.0.12",
  "time",
+]
+
+[[package]]
+name = "tauri-plugin-opener"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "786156aa8e89e03d271fbd3fe642207da8e65f3c961baa9e2930f332bf80a1f5"
+dependencies = [
+ "dunce",
+ "glob",
+ "objc2-app-kit",
+ "objc2-foundation 0.3.1",
+ "open",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.12",
+ "url",
+ "windows 0.61.3",
+ "zbus",
 ]
 
 [[package]]
@@ -4408,7 +4763,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4471,6 +4838,17 @@ name = "typenum"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+
+[[package]]
+name = "uds_windows"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89daebc3e6fd160ac4aa9fc8b3bf71e1f74fbf92367ae71fb83a037e8bf164b9"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "winapi",
+]
 
 [[package]]
 name = "unic-char-property"
@@ -4972,7 +5350,7 @@ dependencies = [
  "windows-collections",
  "windows-core 0.61.2",
  "windows-future",
- "windows-link",
+ "windows-link 0.1.3",
  "windows-numerics",
 ]
 
@@ -5006,7 +5384,7 @@ checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
  "windows-implement 0.60.0",
  "windows-interface 0.59.1",
- "windows-link",
+ "windows-link 0.1.3",
  "windows-result 0.3.4",
  "windows-strings 0.4.2",
 ]
@@ -5018,7 +5396,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
  "windows-core 0.61.2",
- "windows-link",
+ "windows-link 0.1.3",
  "windows-threading",
 ]
 
@@ -5073,13 +5451,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
+name = "windows-link"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+
+[[package]]
 name = "windows-numerics"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -5097,7 +5481,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -5116,7 +5500,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -5153,6 +5537,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
  "windows-targets 0.53.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f109e41dd4a3c848907eb83d5a42ea98b3769495597450cf6d153507b166f0f"
+dependencies = [
+ "windows-link 0.2.0",
 ]
 
 [[package]]
@@ -5208,7 +5601,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -5217,7 +5610,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e04a5c6627e310a23ad2358483286c7df260c964eb2d003d8efd6d0f4e79265c"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -5537,6 +5930,66 @@ dependencies = [
 ]
 
 [[package]]
+name = "zbus"
+version = "5.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d07e46d035fb8e375b2ce63ba4e4ff90a7f73cf2ffb0138b29e1158d2eaadf7"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "nix",
+ "ordered-stream",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "windows-sys 0.60.2",
+ "winnow 0.7.11",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57e797a9c847ed3ccc5b6254e8bcce056494b375b511b3d6edcec0aeb4defaca"
+dependencies = [
+ "proc-macro-crate 3.3.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7be68e64bf6ce8db94f63e72f0c7eb9a60d733f7e0499e628dfab0f84d6bcb97"
+dependencies = [
+ "serde",
+ "static_assertions",
+ "winnow 0.7.11",
+ "zvariant",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5623,4 +6076,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29ce2c8a9384ad323cf564b67da86e21d3cfdff87908bc1223ed5c99bc792713"
 dependencies = [
  "zune-core",
+]
+
+[[package]]
+name = "zvariant"
+version = "5.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "999dd3be73c52b1fccd109a4a81e4fcd20fab1d3599c8121b38d04e1419498db"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow 0.7.11",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6643fd0b26a46d226bd90d3f07c1b5321fe9bb7f04673cb37ac6d6883885b68e"
+dependencies = [
+ "proc-macro-crate 3.3.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6949d142f89f6916deca2232cf26a8afacf2b9fdc35ce766105e104478be599"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.104",
+ "winnow 0.7.11",
 ]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.5.5"
+version = "0.6.0"
 description = "Kasia"
 authors = ["you"]
 license = "ISC"
@@ -29,6 +29,7 @@ tauri-plugin-app-events = {git = "https://github.com/IzioDev/tauri-plugin-app-ev
 rand = "0.9.2"
 tokio = {version = "1.47.1", features = ["time"] }
 tauri-plugin-os = "2"
+tauri-plugin-opener = "2"
 
 # taken from default configuration at https://tauri.app/concept/size/
 [profile.dev]

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -7,6 +7,7 @@
     "core:default",
     "log:default",
     "clipboard-manager:allow-read-text",
-    "biometry:default"
+    "biometry:default",
+    "opener:default"
   ]
 }

--- a/src-tauri/capabilities/mobile.json
+++ b/src-tauri/capabilities/mobile.json
@@ -9,7 +9,8 @@
     "log:default",
     "clipboard-manager:allow-read-text",
     "biometry:default",
-    "barcode-scanner:default"
+    "barcode-scanner:default",
+    "opener:default"
   ],
   "platforms": ["iOS", "android"]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,7 +6,7 @@ use tokio::time::{sleep, Duration};
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
-        .plugin(tauri_plugin_barcode_scanner::init())
+        .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_os::init())
         .plugin(tauri_plugin_clipboard_manager::init())
         .plugin(
@@ -24,6 +24,7 @@ pub fn run() {
                 log::info!("Running on mobile mode.");
 
                 app.handle().plugin(tauri_plugin_biometry::init())?;
+                app.handle().plugin(tauri_plugin_barcode_scanner::init())?;
 
                 let app_handle = app.handle();
                 app_handle.plugin(tauri_plugin_app_events::init())?;

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,13 +1,13 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Kasia",
-  "version": "0.5.5",
+  "version": "0.6.0",
   "identifier": "kas.kluster.kasia",
   "build": {
     "frontendDist": "../dist",
     "devUrl": "http://localhost:3000",
     "beforeDevCommand": "npm run dev",
-    "beforeBuildCommand": "npm run build:staging",
+    "beforeBuildCommand": "npm run build:production",
     "removeUnusedCommands": true
   },
   "app": {

--- a/src/components/Common/ColorPicker.tsx
+++ b/src/components/Common/ColorPicker.tsx
@@ -27,7 +27,7 @@ export const ColorPicker: FC<ColorPickerProps> = ({
           type="text"
           value={color}
           onChange={(e) => onChange(e.target.value)}
-          className="w-16 rounded border border-[var(--primary-border)] bg-[var(--input-bg)] px-1 py-1 text-xs text-[var(--text-primary)]"
+          className="w-16 rounded border border-[var(--primary-border)] bg-[var(--input-bg)] px-1 py-1 text-base text-[var(--text-primary)] sm:text-xs"
           placeholder="#000000"
         />
       </div>

--- a/src/components/Common/HoldToAction.tsx
+++ b/src/components/Common/HoldToAction.tsx
@@ -187,6 +187,8 @@ export const HoldToAction: FC<HoldToActionProps> = ({
         onBlur={stopHold}
         onClick={(e) => e.preventDefault()}
       >
+        {/* span to increate butotn push area on touch devices */}
+        <span className="absolute w-full p-7 pointer-fine:hidden"></span>
         {isHolding && (
           <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
             <svg

--- a/src/components/Common/HoldToAction.tsx
+++ b/src/components/Common/HoldToAction.tsx
@@ -174,7 +174,7 @@ export const HoldToAction: FC<HoldToActionProps> = ({
         aria-label={ariaLabel}
         disabled={disabled}
         className={clsx(
-          "flex cursor-pointer items-center justify-center text-[var(--text-primary)] focus:outline-none",
+          "flex cursor-pointer items-center justify-center text-[var(--text-primary)] select-none focus:outline-none",
           hoverClass,
           hasAbsolutePositioning ? "" : "relative",
           sizeClasses[size]

--- a/src/components/EditNicknamePopover.tsx
+++ b/src/components/EditNicknamePopover.tsx
@@ -45,7 +45,7 @@ const EditNicknameInput: FC<{
         onCancel();
       }
     }}
-    className="w-full rounded border border-[var(--primary-border)] bg-[var(--secondary-bg)] px-2 py-1 text-sm text-[var(--text-primary)]"
+    className="w-full rounded border border-[var(--primary-border)] bg-[var(--secondary-bg)] px-2 py-1 text-base text-[var(--text-primary)] sm:text-sm"
     autoFocus
   />
 );

--- a/src/components/Layout/ModalHost.tsx
+++ b/src/components/Layout/ModalHost.tsx
@@ -14,6 +14,7 @@ import { ImagePresenter } from "../Modals/ImagePresenter";
 import { BroadcastParticipantInfo } from "../Modals/BroadcastParticipantInfo";
 import { QrScannerModal } from "../Modals/QrScannerModal";
 import { OffChainHandshakeModal } from "../Modals/OffChainHandshakeModal";
+import { DeleteWalletModal } from "../Modals/DeleteWalletModal";
 import { useBroadcastStore } from "../../store/broadcast.store";
 
 // This component subscribes to modal state and renders the appropriate modal
@@ -145,6 +146,14 @@ export const ModalHost = () => {
           isOpen={modals["offchain-handshake"] || false}
           onClose={() => closeModal("offchain-handshake")}
           kaspaAddress={walletStore.address?.toString() || ""}
+        />
+      )}
+
+      {/* Delete Wallet Modal */}
+      {modals.delete && (
+        <DeleteWalletModal
+          isOpen={modals.delete || false}
+          onClose={() => closeModal("delete")}
         />
       )}
     </>

--- a/src/components/Layout/RootLayout.tsx
+++ b/src/components/Layout/RootLayout.tsx
@@ -35,7 +35,7 @@ export const RootLayout: FC = () => {
   }, [location]);
 
   return (
-    <div className="m-0 p-0 font-['Inter',-apple-system,BlinkMacSystemFont,'Segoe_UI',Roboto,sans-serif] leading-relaxed text-[var(--text-primary)]">
+    <>
       <ToastContainer />
       <ModalHost />
       <ResizableAppContainer>
@@ -59,6 +59,6 @@ export const RootLayout: FC = () => {
 
         <Outlet />
       </ResizableAppContainer>
-    </div>
+    </>
   );
 };

--- a/src/components/Layout/TrustMessage.tsx
+++ b/src/components/Layout/TrustMessage.tsx
@@ -27,7 +27,7 @@ export const TrustMessage: FC = () => {
     <div className="mb-2 sm:mb-5">
       {/* trust message section */}
       <div
-        className="border-kas-secondary from-kas-secondary/20 to-kas-secondary/5 mt-6 cursor-pointer rounded-2xl border bg-gradient-to-r p-2"
+        className="border-kas-secondary from-kas-secondary/20 to-kas-secondary/5 mt-6 cursor-pointer rounded-2xl border bg-gradient-to-r p-1 sm:p-2"
         onClick={() => setOpenTrust((v) => !v)}
       >
         <div
@@ -68,7 +68,7 @@ export const TrustMessage: FC = () => {
 
       {/* why kaspa wallet section */}
       <div
-        className="border-primary-border bg-primary-bg mt-3 cursor-pointer rounded-2xl border p-2"
+        className="border-primary-border bg-primary-bg mt-3 cursor-pointer rounded-2xl border p-1 sm:p-2"
         onClick={() => setOpenWhy((v) => !v)}
       >
         <div className="flex w-full items-center justify-center gap-2 py-1">
@@ -87,7 +87,7 @@ export const TrustMessage: FC = () => {
         {/* Collapsible Content */}
         <div
           className={`overflow-hidden transition-all duration-300 ease-in-out ${
-            openWhy ? "mt-2 max-h-fit opacity-100" : "max-h-0 opacity-0"
+            openWhy ? "mt-2 max-h-40 opacity-100" : "max-h-0 opacity-0"
           }`}
         >
           <p className="break-word w-full text-center text-sm leading-relaxed text-[var(--text-secondary)]">

--- a/src/components/MessagesPane/Composing/Utilities/InputBasic.tsx
+++ b/src/components/MessagesPane/Composing/Utilities/InputBasic.tsx
@@ -95,7 +95,7 @@ export const InputBasic = forwardRef<HTMLTextAreaElement, InputBasicProps>(
         maxLength={MAX_CHAT_INPUT_CHAR + 1}
         className={clsx(
           className ||
-            "peer bg-primary-bg box-border flex-1 resize-none rounded-3xl py-3 pr-20 pl-4 text-sm text-[var(--text-primary)]",
+            "peer bg-primary-bg box-border flex-1 resize-none rounded-3xl py-3 pr-20 pl-4 text-base text-[var(--text-primary)] sm:text-sm",
           showScroll ? "overflow-y-auto" : "overflow-y-hidden",
           onDragOver ? "border-kas-secondary border" : "outline-none"
         )}

--- a/src/components/MessagesPane/Utilities/Meta/ExplorerLink.tsx
+++ b/src/components/MessagesPane/Utilities/Meta/ExplorerLink.tsx
@@ -1,6 +1,8 @@
-import { FC } from "react";
+import type { FC } from "react";
 import { Tickets } from "lucide-react";
 import { getExplorerUrl } from "../../../../utils/explorer-url";
+import { core } from "@tauri-apps/api";
+import { openUrl } from "@tauri-apps/plugin-opener";
 
 type ExplorerLinkProps = {
   transactionId: string;
@@ -15,10 +17,24 @@ export const ExplorerLink: FC<ExplorerLinkProps> = ({
 }) => {
   const containerClass = position === "left" ? "ml-2" : "mr-2";
 
+  const href = getExplorerUrl(transactionId, network);
+
+  const handleClick: React.MouseEventHandler<HTMLAnchorElement> = async (e) => {
+    if (core.isTauri()) {
+      if (e.defaultPrevented) return;
+      if (e.button !== 0) return;
+      if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
+
+      e.preventDefault();
+      await openUrl(href);
+    }
+  };
+
   return (
     <div className={`${containerClass} flex items-center`}>
       <a
-        href={getExplorerUrl(transactionId, network)}
+        href={href}
+        onClick={handleClick}
         target="_blank"
         rel="noopener noreferrer"
         className="text-xs opacity-80 transition-opacity hover:text-[var(--kas-primary)] active:scale-90 active:opacity-60"

--- a/src/components/MessagesPane/Utilities/Utils/BubbleClassGenerator.tsx
+++ b/src/components/MessagesPane/Utilities/Utils/BubbleClassGenerator.tsx
@@ -52,7 +52,7 @@ export const generateBubbleClasses = ({
   };
 
   return clsx(
-    "relative z-0 max-w-[70%] cursor-pointer px-4 py-1 text-left break-words hyphens-auto",
+    "relative z-0 sm:max-w-[70%] max-w-[90%] cursor-pointer px-4 py-1 text-left break-words hyphens-auto",
     getBackgroundClass(),
     bubbleClass,
     className

--- a/src/components/Modals/DeleteWalletModal.tsx
+++ b/src/components/Modals/DeleteWalletModal.tsx
@@ -1,0 +1,80 @@
+import { FC } from "react";
+import { Modal } from "../Common/modal";
+import { Button } from "../Common/Button";
+import { WarningBlock } from "../Common/WarningBlock";
+import { useUiStore } from "../../store/ui.store";
+import { useWalletStore } from "../../store/wallet.store";
+
+interface DeleteWalletModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export const DeleteWalletModal: FC<DeleteWalletModalProps> = ({
+  isOpen,
+  onClose,
+}) => {
+  const pendingDeleteWalletId = useUiStore((s) => s.pendingDeleteWalletId);
+  const setPendingDeleteWalletId = useUiStore(
+    (s) => s.setPendingDeleteWalletId
+  );
+  const wallets = useWalletStore((s) => s.wallets);
+  const deleteWallet = useWalletStore((s) => s.deleteWallet);
+  const loadWallets = useWalletStore((s) => s.loadWallets);
+
+  const wallet = pendingDeleteWalletId
+    ? wallets.find((w) => w.id === pendingDeleteWalletId) || null
+    : null;
+
+  const handleConfirm = () => {
+    if (pendingDeleteWalletId) {
+      deleteWallet(pendingDeleteWalletId);
+      loadWallets();
+      setPendingDeleteWalletId(null);
+    }
+    onClose();
+  };
+
+  const handleCancel = () => {
+    setPendingDeleteWalletId(null);
+    onClose();
+  };
+
+  if (!isOpen || !wallet) return null;
+
+  return (
+    <Modal onClose={handleCancel} className="max-w-sm select-none">
+      <div className="w-full p-2">
+        <h2 className="mb-4 text-xl font-semibold text-[var(--text-primary)]">
+          Delete Wallet
+        </h2>
+
+        <p className="mb-6 text-center text-[var(--text-secondary)] sm:text-left">
+          Are you sure you want to delete the wallet{" "}
+          <span className="font-semibold text-[var(--text-primary)]">
+            "{wallet.name}"
+          </span>
+          ?
+        </p>
+
+        <WarningBlock title="Warning" className="mb-6">
+          This action cannot be undone. All wallet data will be permanently
+          removed.
+        </WarningBlock>
+
+        <div className="flex gap-3">
+          <Button variant="secondary" onClick={handleCancel} className="flex-1">
+            Cancel
+          </Button>
+          <Button
+            variant="primary"
+            onClick={handleConfirm}
+            className="flex-1 !bg-[var(--accent-red)]/80 hover:!bg-[var(--accent-red)]/70"
+          >
+            Delete
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+};

--- a/src/components/Modals/NewChatForm.tsx
+++ b/src/components/Modals/NewChatForm.tsx
@@ -88,11 +88,14 @@ export const NewChatForm: React.FC<NewChatFormProps> = ({ onClose }) => {
     }
   }, [recipientInputValue]);
 
-  const useRecipientInputRef = (node: HTMLTextAreaElement | null) => {
-    if (node) {
-      node.focus();
+  const recipientInputRef = useRef<HTMLTextAreaElement>(null);
+
+  // Focus the address input on mount only (not ever render)
+  useEffect(() => {
+    if (recipientInputRef.current) {
+      recipientInputRef.current.focus();
     }
-  };
+  }, []);
 
   // Handle escape key to close
   useEffect(() => {
@@ -436,7 +439,7 @@ export const NewChatForm: React.FC<NewChatFormProps> = ({ onClose }) => {
           </label>
           <div className="relative">
             <Textarea
-              ref={useRecipientInputRef}
+              ref={recipientInputRef}
               className="bg-primary-bg border-primary-border w-full resize-none rounded-lg border p-2 pr-24 text-base text-[var(--text-primary)] placeholder-gray-400 focus:border-[var(--button-primary)]/80 focus:ring-2 focus:outline-none"
               rows={3}
               id="recipientAddress"

--- a/src/components/Modals/NewChatForm.tsx
+++ b/src/components/Modals/NewChatForm.tsx
@@ -437,7 +437,7 @@ export const NewChatForm: React.FC<NewChatFormProps> = ({ onClose }) => {
           <div className="relative">
             <Textarea
               ref={useRecipientInputRef}
-              className="bg-primary-bg border-primary-border w-full resize-none rounded-lg border p-2 pr-24 text-sm text-[var(--text-primary)] placeholder-gray-400 focus:border-[var(--button-primary)]/80 focus:ring-2 focus:outline-none"
+              className="bg-primary-bg border-primary-border w-full resize-none rounded-lg border p-2 pr-24 text-base text-[var(--text-primary)] placeholder-gray-400 focus:border-[var(--button-primary)]/80 focus:ring-2 focus:outline-none"
               rows={3}
               id="recipientAddress"
               value={recipientInputValue}
@@ -519,7 +519,7 @@ export const NewChatForm: React.FC<NewChatFormProps> = ({ onClose }) => {
             Handshake Amount (KAS)
           </label>
           <input
-            className="border-primary-border focus:ring-kas-secondary/80 bg-input-bg mb-2 box-border flex h-10 w-full items-center rounded-lg border px-3 py-2 focus:ring-2 focus:outline-none"
+            className="border-primary-border focus:ring-kas-secondary/80 bg-input-bg mb-2 box-border flex h-10 w-full items-center rounded-lg border px-3 py-2 text-base focus:ring-2 focus:outline-none"
             type="text"
             id="handshakeAmount"
             value={handshakeAmount}

--- a/src/components/Modals/OffChainHandshakeModal.tsx
+++ b/src/components/Modals/OffChainHandshakeModal.tsx
@@ -352,7 +352,7 @@ export const OffChainHandshakeModal: React.FC<OffChainHandshakeModalProps> = ({
             <div className={blockVisible(isQrOpen)}>
               <div className="relative">
                 <Textarea
-                  className="bg-primary-bg border-primary-border w-full resize-none rounded-lg border p-2 pr-20 text-sm text-[var(--text-primary)] placeholder-gray-400 focus:border-[var(--button-primary)]/80 focus:ring-2 focus:outline-none"
+                  className="bg-primary-bg border-primary-border w-full resize-none rounded-lg border p-2 pr-20 text-base text-[var(--text-primary)] placeholder-gray-400 focus:border-[var(--button-primary)]/80 focus:ring-2 focus:outline-none"
                   rows={2}
                   value={partnerAddress}
                   onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
@@ -453,7 +453,7 @@ export const OffChainHandshakeModal: React.FC<OffChainHandshakeModalProps> = ({
                     <div className="relative">
                       <input
                         type="text"
-                        className="border-primary-border bg-primary-bg flex min-h-14 w-full cursor-text items-center rounded-lg border px-3 py-2 pr-20 font-mono text-[13px] leading-[1.4] break-all text-[var(--text-primary)] placeholder-gray-400 transition-colors focus:border-[var(--button-primary)]/80 focus:ring-2 focus:outline-none"
+                        className="border-primary-border bg-primary-bg flex min-h-14 w-full cursor-text items-center rounded-lg border px-3 py-2 pr-20 font-mono text-base leading-[1.4] break-all text-[var(--text-primary)] placeholder-gray-400 transition-colors focus:border-[var(--button-primary)]/80 focus:ring-2 focus:outline-none"
                         value={theirAliasForUs}
                         onChange={(e) => updateTheirAlias(e.target.value)}
                         placeholder="Enter the alias your partner generated for you"

--- a/src/components/Modals/SettingsModal.tsx
+++ b/src/components/Modals/SettingsModal.tsx
@@ -992,13 +992,14 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
                 </div>
               </div>
             )}
+
+            {/* App Version */}
+            {isMobile && (
+              <div className="mt-6 flex w-full items-center justify-center">
+                <AppVersion />
+              </div>
+            )}
           </div>
-          {/* App Version Mobile */}
-          {isMobile ? (
-            <div className="absolute bottom-4 left-0 flex w-full items-center justify-center">
-              <AppVersion />
-            </div>
-          ) : null}
         </div>
       </div>
     </Modal>

--- a/src/components/Modals/SettingsModal.tsx
+++ b/src/components/Modals/SettingsModal.tsx
@@ -565,7 +565,7 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
                               id="wallet-name"
                               value={newWalletName}
                               onChange={(e) => setNewWalletName(e.target.value)}
-                              className="border-primary-border bg-primary-bg text-primary focus:ring-kas-secondary/80 w-full rounded-lg border p-3 text-sm focus:ring-2 focus:outline-none"
+                              className="border-primary-border bg-primary-bg text-primary focus:ring-kas-secondary/80 w-full rounded-lg border p-3 text-base focus:ring-2 focus:outline-none sm:text-sm"
                               placeholder="Enter wallet name"
                               disabled={isChangingName}
                               maxLength={50}
@@ -833,7 +833,7 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
                             name="current-password"
                             label="Current Password"
                             classLabel="mb-2 block text-sm font-medium"
-                            classInput="border-primary-border bg-primary-bg text-primary focus:ring-kas-secondary/80 w-full rounded-lg border p-3 text-sm focus:ring-2 focus:outline-none"
+                            classInput="border-primary-border bg-primary-bg text-primary focus:ring-kas-secondary/80 w-full rounded-lg border p-3 text-base sm:text-sm focus:ring-2 focus:outline-none"
                             value={currentPassword}
                             onChange={(e) => setCurrentPassword(e.target.value)}
                             disabled={isChangingPassword}
@@ -846,7 +846,7 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
                             name="new-password"
                             label="New Password"
                             classLabel="mb-2 block text-sm font-medium"
-                            classInput="border-primary-border bg-primary-bg text-primary focus:ring-kas-secondary/80 w-full rounded-lg border p-3 text-sm focus:ring-2 focus:outline-none"
+                            classInput="border-primary-border bg-primary-bg text-primary focus:ring-kas-secondary/80 w-full rounded-lg border p-3 text-base sm:text-sm focus:ring-2 focus:outline-none"
                             value={newPassword}
                             onChange={(e) => setNewPassword(e.target.value)}
                             disabled={isChangingPassword}
@@ -859,7 +859,7 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
                             name="confirm-password"
                             label="Confirm Password"
                             classLabel="mb-2 block text-sm font-medium"
-                            classInput="border-primary-border bg-primary-bg text-primary focus:ring-kas-secondary/80 w-full rounded-lg border p-3 text-sm focus:ring-2 focus:outline-none"
+                            classInput="border-primary-border bg-primary-bg text-primary focus:ring-kas-secondary/80 w-full rounded-lg border p-3 text-base sm:text-sm focus:ring-2 focus:outline-none"
                             value={confirmPassword}
                             onChange={(e) => setConfirmPassword(e.target.value)}
                             disabled={isChangingPassword}

--- a/src/components/Modals/SettingsModal.tsx
+++ b/src/components/Modals/SettingsModal.tsx
@@ -40,8 +40,9 @@ import { useDBStore } from "../../store/db.store";
 import { useSessionState } from "../../store/session.store";
 import { WarningBlock } from "../Common/WarningBlock";
 import { PasswordField } from "../Common/PasswordField";
+import { HoldToDelete } from "../Common/HoldToDelete";
 import { AppVersion } from "../App/AppVersion";
-
+import { toast } from "../../utils/toast-helper";
 interface SettingsModalProps {
   isOpen: boolean;
   onClose: () => void;
@@ -125,6 +126,9 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
   // Import/Export messages state
   const [showImportExport, setShowImportExport] = useState(false);
 
+  // Delete all messages state
+  const [showDeleteAll, setShowDeleteAll] = useState(false);
+
   // Custom theme state
   const [showCustomTheme, setShowCustomTheme] = useState(false);
 
@@ -150,15 +154,8 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
 
   const onClearHistory = async () => {
     if (!unlockedWallet) return;
-    if (
-      confirm(
-        "Are you sure you want to clear ALL message history? This will completely wipe all conversations, messages, nicknames, and handshakes. This cannot be undone."
-      )
-    ) {
-      await messageStore.flushWalletHistory(unlockedWallet.id);
 
-      onClose();
-    }
+    await messageStore.flushWalletHistory(unlockedWallet.id);
   };
 
   const handlePasswordChange = async () => {
@@ -296,6 +293,10 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
 
   const initializeImportExport = () => {
     setShowImportExport(true);
+  };
+
+  const initializeDeleteAll = () => {
+    setShowDeleteAll(true);
   };
 
   const initializeCustomTheme = () => {
@@ -459,7 +460,7 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
           >
             {activeTab === "account" && (
               <div className="mt-3 space-y-6 sm:mt-0">
-                {!showNameChange && !showImportExport ? (
+                {!showNameChange && !showImportExport && !showDeleteAll ? (
                   <>
                     <h3 className="mb-4 text-lg font-medium">Account</h3>
                     <div className="space-y-2">
@@ -510,7 +511,7 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
 
                       {/* Delete All Messages */}
                       <button
-                        onClick={onClearHistory}
+                        onClick={initializeDeleteAll}
                         type="button"
                         className="bg-primary-bg hover:bg-primary-bg/50 border-primary-border flex w-full cursor-pointer items-center gap-3 rounded-2xl border p-4 transition-all duration-200 active:rounded-4xl"
                       >
@@ -621,6 +622,50 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
                       </h3>
                     </div>
                     <MessageBackup />
+                  </>
+                ) : showDeleteAll ? (
+                  <>
+                    <div className="mb-2 flex items-center gap-3">
+                      <button
+                        onClick={() => setShowDeleteAll(false)}
+                        className="hover:text-primary text-muted-foreground cursor-pointer p-1 transition-colors"
+                      >
+                        <ArrowLeft className="h-5 w-5" />
+                      </button>
+                      <h3 className="text-lg font-medium">
+                        Delete All Messages
+                      </h3>
+                    </div>
+
+                    <div className="space-y-4">
+                      <WarningBlock title="Warning">
+                        All messages, conversations, nicknames, and handshakes
+                        will be deleted from device.
+                      </WarningBlock>
+
+                      <div className="border-primary-border bg-primary-bg rounded-2xl border p-4">
+                        <div className="mb-4 text-sm font-medium">
+                          Confirm Deletion
+                        </div>
+                        <div className="text-muted-foreground mb-4 text-sm">
+                          Click and hold the delete button below to confirm you
+                          want to permanently delete all messages.
+                        </div>
+                        <div className="flex justify-center">
+                          <HoldToDelete
+                            onComplete={() => {
+                              onClearHistory();
+                              toast.success("Messages Deleted");
+                              setShowDeleteAll(false);
+                            }}
+                            size="xl"
+                            className="text-[var(--text-secondary)]"
+                            title="Click and hold to delete all messages"
+                            hoverClass="hover:text-red-500"
+                          />
+                        </div>
+                      </div>
+                    </div>
                   </>
                 ) : null}
               </div>

--- a/src/components/Modals/SettingsModal.tsx
+++ b/src/components/Modals/SettingsModal.tsx
@@ -444,7 +444,9 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
 
               {!isMobile ? (
                 <div className="absolute bottom-4 left-0 flex w-full items-center justify-center">
-                  <AppVersion />
+                  {(activeTab === "account" || activeTab === "dev") && (
+                    <AppVersion />
+                  )}
                 </div>
               ) : null}
             </nav>
@@ -1039,7 +1041,7 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
             )}
 
             {/* App Version */}
-            {isMobile && (
+            {isMobile && (activeTab === "account" || activeTab === "dev") && (
               <div className="mt-6 flex w-full items-center justify-center">
                 <AppVersion />
               </div>

--- a/src/components/Modals/WalletWithdrawal.tsx
+++ b/src/components/Modals/WalletWithdrawal.tsx
@@ -175,7 +175,7 @@ export const WalletWithdrawal: FC = () => {
             onChange={(e) => setWithdrawAddress(e.target.value)}
             placeholder="Enter Kaspa address"
             rows={3}
-            className="border-primary-border focus:ring-kas-secondary/80 bg-primary-bg w-full resize-none rounded-lg border p-2 pr-24 break-words whitespace-pre-wrap focus:ring-2 focus:outline-none"
+            className="border-primary-border focus:ring-kas-secondary/80 bg-primary-bg w-full resize-none rounded-lg border p-2 pr-24 text-base break-words whitespace-pre-wrap focus:ring-2 focus:outline-none sm:text-sm"
           />
           <div className="absolute right-2 bottom-2 flex gap-1 pb-1">
             <button

--- a/src/components/ModeSelector.tsx
+++ b/src/components/ModeSelector.tsx
@@ -1,6 +1,7 @@
 import { FC } from "react";
 import { Menu, MenuButton, MenuItems, MenuItem } from "@headlessui/react";
 import { MessageCircle, Radio } from "lucide-react";
+import { toast } from "../utils/toast-helper";
 
 type ModeSelectorProps = {
   onModeChange: (isBroadcastMode: boolean) => void;
@@ -27,7 +28,7 @@ export const ModeSelector: FC<ModeSelectorProps> = ({
   const modes = [
     {
       id: "chat",
-      displayableString: "Chat",
+      displayableString: "DMs",
       icon: <MessageCircle className="size-5" />,
       value: false,
     },
@@ -39,6 +40,30 @@ export const ModeSelector: FC<ModeSelectorProps> = ({
     },
   ];
 
+  // if fewer than 3 modes, handle direct toggle with toast
+  if (modes.length < 3) {
+    const handleToggle = () => {
+      const newMode = !isBroadcastMode;
+      const selectedMode = modes.find((mode) => mode.value === newMode);
+
+      onModeChange(newMode);
+      setTimeout(() => {
+        toast.info(`Switched to ${selectedMode?.displayableString}`);
+      }, 100);
+    };
+
+    return (
+      <button
+        onClick={handleToggle}
+        className="text-text-primary hover:bg-primary-bg/50 inline-flex size-10 cursor-pointer items-center justify-center rounded transition-colors duration-200 hover:text-[var(--kas-primary)] active:scale-90 active:opacity-80"
+      >
+        {modeIcon}
+      </button>
+    );
+  }
+
+  // behavior for 3+ modes
+  // unused atm but will be used when (if) games is introduced
   return (
     <Menu>
       <MenuButton className="text-text-primary hover:bg-primary-bg/50 inline-flex size-10 cursor-pointer items-center justify-center rounded transition-colors duration-200 hover:text-[var(--kas-primary)] active:scale-90 active:opacity-80">

--- a/src/components/SendPaymentPopup.tsx
+++ b/src/components/SendPaymentPopup.tsx
@@ -10,6 +10,7 @@ import { Address } from "kaspa-wasm";
 import { toast } from "../utils/toast-helper";
 import { KasiaTransaction } from "../types/all";
 import { PROTOCOL } from "../config/protocol";
+import { useIsMobile } from "../hooks/useIsMobile";
 
 export const SendPaymentPopup: FC<{
   address: string;
@@ -27,6 +28,7 @@ export const SendPaymentPopup: FC<{
   const storeKasiaTransactions = useMessagingStore(
     (s) => s.storeKasiaTransactions
   );
+  const isMobile = useIsMobile();
 
   // Close panel on outside click
   useEffect(() => {
@@ -253,7 +255,12 @@ export const SendPaymentPopup: FC<{
       {panelOpen && (
         <div
           ref={panelRef}
-          className="absolute bottom-full left-0 z-50 mt-3 mb-20 block min-w-[320px] translate-y-2/5 transform rounded-lg border border-[var(--border-color)] bg-[var(--secondary-bg)] p-4 shadow-2xl shadow-(color:--button-primary)/30 transition duration-200 ease-out sm:translate-y-1/2"
+          className={clsx(
+            "block transform rounded-lg border border-[var(--border-color)] bg-[var(--secondary-bg)] p-4 shadow-2xl shadow-(color:--button-primary)/30 transition duration-200 ease-out",
+            isMobile
+              ? "fixed bottom-0 left-0 z-50 w-screen min-w-[320px] rounded-t-lg"
+              : "absolute bottom-full left-0 z-50 mt-3 mb-20 w-full min-w-[320px] translate-y-2/5 sm:translate-y-1/2"
+          )}
         >
           <div className="mb-3 flex items-center justify-between">
             <h4 className="text-sm font-medium text-[var(--text-primary)]">
@@ -275,7 +282,7 @@ export const SendPaymentPopup: FC<{
                 }
                 disabled={!canSendMessageWithPayment}
                 className={clsx(
-                  "w-full rounded-md border border-[var(--border-color)] bg-[var(--primary-bg)] px-3 py-2 text-sm text-[var(--text-primary)] focus:border-transparent focus:ring-2 focus:ring-[#70C7BA] focus:outline-none",
+                  "min-h-[44px] w-full rounded-md border border-[var(--border-color)] bg-[var(--primary-bg)] px-3 py-2 text-base text-[var(--text-primary)] focus:border-transparent focus:ring-2 focus:ring-[#70C7BA] focus:outline-none",
                   {
                     "cursor-not-allowed opacity-50": !canSendMessageWithPayment,
                   }
@@ -297,7 +304,7 @@ export const SendPaymentPopup: FC<{
                     value={payAmount}
                     onChange={(e) => handlePayAmountChange(e.target.value)}
                     placeholder="Amount (KAS)"
-                    className="w-full rounded-md border border-[var(--border-color)] bg-[var(--primary-bg)] px-3 py-2 pr-12 text-sm text-[var(--text-primary)] focus:border-transparent focus:ring-2 focus:ring-[#70C7BA] focus:outline-none"
+                    className="min-h-[44px] w-full rounded-md border border-[var(--border-color)] bg-[var(--primary-bg)] px-3 py-2 pr-12 text-base text-[var(--text-primary)] focus:border-transparent focus:ring-2 focus:ring-[#70C7BA] focus:outline-none"
                   />
                   <button
                     type="button"

--- a/src/components/SideBarPane/HoldablePlusButton.tsx
+++ b/src/components/SideBarPane/HoldablePlusButton.tsx
@@ -38,7 +38,7 @@ export const HoldablePlusButton: FC<HoldablePlusButtonProps> = ({
 
   return (
     <HoldToAction
-      holdDuration={1200}
+      holdDuration={1000}
       animationDelay={200}
       onShortPress={handleShortPress}
       onLongPress={handleLongPress}

--- a/src/components/SideBarPane/SidebarSection.tsx
+++ b/src/components/SideBarPane/SidebarSection.tsx
@@ -119,20 +119,22 @@ export const SidebarSection: FC<SidebarSectionProps> = ({
                 </button>
               )}
             </div>
-            {broadcastEnabled && !showSearch && (
-              <ModeSelector
-                onModeChange={onModeChange}
+            <div className="flex gap-2">
+              {broadcastEnabled && !showSearch && (
+                <ModeSelector
+                  onModeChange={onModeChange}
+                  isBroadcastMode={isBroadcastMode}
+                  shouldShow={broadcastEnabled && !showSearch}
+                />
+              )}
+              <HoldablePlusButton
+                broadcastEnabled={broadcastEnabled}
                 isBroadcastMode={isBroadcastMode}
-                shouldShow={broadcastEnabled && !showSearch}
+                onNewChat={handleNewChat}
+                onOffChainHandshake={handleOffChainHandshake}
+                onNewBroadcast={handleNewBroadcast}
               />
-            )}
-            <HoldablePlusButton
-              broadcastEnabled={broadcastEnabled}
-              isBroadcastMode={isBroadcastMode}
-              onNewChat={handleNewChat}
-              onOffChainHandshake={handleOffChainHandshake}
-              onNewBroadcast={handleNewBroadcast}
-            />
+            </div>
           </div>
         ) : (
           /* Plus button when collapsed */

--- a/src/components/WalletLockedFlow/Home.tsx
+++ b/src/components/WalletLockedFlow/Home.tsx
@@ -70,7 +70,7 @@ export const Home = ({
             }
             className="hover:border-kas-secondary border-primary-border group focus-visible:ring-kas-secondary relative flex min-h-14 cursor-pointer flex-col items-center gap-2 rounded-xl border bg-[var(--primary-bg)] p-3 pr-16 text-center transition-all duration-200 outline-none hover:bg-[var(--primary-bg)]/50 hover:shadow-sm focus-visible:ring-2 active:rounded-4xl sm:flex-row sm:items-center sm:justify-between sm:p-4 sm:pr-20 sm:text-left"
           >
-            <div className="flex w-full flex-col items-center gap-1 sm:flex-1 sm:items-start">
+            <div className="flex w-full flex-col items-center gap-1 select-none sm:flex-1 sm:items-start">
               <div className="flex flex-wrap items-center justify-center gap-2 sm:justify-start">
                 <span className="max-w-full truncate font-semibold text-[var(--text-primary)] sm:max-w-lg">
                   {w.name}
@@ -96,14 +96,16 @@ export const Home = ({
               </time>
             </div>
 
-            <div className="absolute top-1/2 right-3 flex -translate-y-1/2 items-center gap-3">
-              <HoldToDelete
-                onComplete={() => onDeleteWallet(w.id)}
-                size="md"
-                className="z-20 text-[var(--text-secondary)] transition-all duration-600 sm:opacity-0 sm:group-hover:opacity-70"
-                title="Click and hold to delete wallet"
-                hoverClass="hover:text-red-500"
-              />
+            <div className="pointer-events-none absolute top-1/2 right-3 flex -translate-y-1/2 items-center gap-3">
+              <div className="pointer-events-auto">
+                <HoldToDelete
+                  onComplete={() => onDeleteWallet(w.id)}
+                  size="md"
+                  className="z-20 text-[var(--text-secondary)] transition-all duration-600 sm:opacity-0 sm:group-hover:opacity-70"
+                  title="Click and hold to delete wallet"
+                  hoverClass="hover:text-red-500"
+                />
+              </div>
               <ChevronRight
                 aria-hidden
                 className="pointer-events-none hidden size-6 text-[var(--text-secondary)] opacity-40 transition-transform duration-200 group-hover:translate-x-0.5 sm:block"

--- a/src/containers/MessengerProvider.tsx
+++ b/src/containers/MessengerProvider.tsx
@@ -51,6 +51,7 @@ export const MessengerProvider: FC = () => {
     if (walletStore.unlockedWallet) setIsWalletReady(true);
   }, [walletStore.unlockedWallet]);
 
+  // TODO: eventually refactor this and the UE below this one.
   // effect to restore last opened conversation after messages are loaded (desktop only)
   useEffect(() => {
     if (
@@ -132,6 +133,65 @@ export const MessengerProvider: FC = () => {
     walletStore.address,
     isMobile,
     isCurrentlyInBroadcastMode,
+    navigate,
+    walletId,
+  ]);
+
+  // effect to restore last opened broadcast channel after messages are loaded (desktop only)
+  useEffect(() => {
+    if (
+      !isMobile &&
+      messageStore.isLoaded &&
+      walletStore.isAccountServiceRunning &&
+      !channelId &&
+      isCurrentlyInBroadcastMode &&
+      useBroadcastStore.getState().channels.length > 0
+    ) {
+      const walletAddress = walletStore.address?.toString();
+      if (walletAddress) {
+        try {
+          // get the last opened channel id from localstorage
+          const lastOpenedChannelId = localStorage.getItem(
+            `kasia_last_opened_channel_id_${walletAddress}`
+          );
+
+          if (lastOpenedChannelId) {
+            // check if the channel still exists
+            const broadcastStore = useBroadcastStore.getState();
+            const channelExists = broadcastStore.channels.some(
+              (channel) => channel.id === lastOpenedChannelId
+            );
+
+            if (channelExists) {
+              navigate(`/${walletId}/broadcasts/${lastOpenedChannelId}`, {
+                replace: true,
+              });
+              return;
+            }
+          }
+
+          // fallback: select the first available channel
+          const firstChannel = useBroadcastStore.getState().channels[0];
+          if (firstChannel) {
+            navigate(`/${walletId}/broadcasts/${firstChannel.id}`, {
+              replace: true,
+            });
+          }
+        } catch (error) {
+          console.error(
+            "Error restoring last opened broadcast channel:",
+            error
+          );
+        }
+      }
+    }
+  }, [
+    messageStore.isLoaded,
+    channelId,
+    isCurrentlyInBroadcastMode,
+    walletStore.isAccountServiceRunning,
+    walletStore.address,
+    isMobile,
     navigate,
     walletId,
   ]);

--- a/src/containers/WalletLockedFlowContainer.tsx
+++ b/src/containers/WalletLockedFlowContainer.tsx
@@ -40,6 +40,9 @@ export const WalletLockedFlowContainer = ({
   const navigate = useNavigate();
   const { wallet } = useParams<{ wallet: string }>();
   const openModal = useUiStore((s) => s.openModal);
+  const setPendingDeleteWalletId = useUiStore(
+    (s) => s.setPendingDeleteWalletId
+  );
 
   const isMobile = useIsMobile();
 
@@ -54,7 +57,6 @@ export const WalletLockedFlowContainer = ({
     unlockedWallet,
     loadWallets,
     selectWallet,
-    deleteWallet,
   } = useWalletStore();
 
   useEffect(() => {
@@ -99,9 +101,8 @@ export const WalletLockedFlowContainer = ({
   };
 
   const onDeleteWallet = (walletId: string) => {
-    if (window.confirm("Are you sure you want to delete this wallet?")) {
-      deleteWallet(walletId);
-    }
+    setPendingDeleteWalletId(walletId);
+    openModal("delete");
   };
 
   const onSelectWallet = (wallet: Wallet) => {

--- a/src/hooks/useOrchestrator.ts
+++ b/src/hooks/useOrchestrator.ts
@@ -8,6 +8,7 @@ import { useDBStore } from "../store/db.store";
 import { UnlockedWallet } from "../types/wallet.type";
 import { useLiveStore } from "../store/live.store";
 import { useBroadcastStore } from "../store/broadcast.store";
+import { useFeatureFlagsStore, FeatureFlags } from "../store/featureflag.store";
 
 export type ConnectOpts = {
   networkType?: NetworkType;
@@ -125,6 +126,22 @@ export const useOrchestrator = () => {
     });
 
     await messagingStore.load(receivedAddressString);
+
+    // load broadcast channels async so we can start processing them straight away
+    const isBroadcastEnabled =
+      useFeatureFlagsStore.getState().flags[FeatureFlags.BROADCAST];
+    if (isBroadcastEnabled) {
+      useBroadcastStore
+        .getState()
+        .loadChannels()
+        .then(() => console.log("Broadcast channels loaded"))
+        .catch((error) =>
+          console.error(
+            "Failed to load broadcast channels during initialization:",
+            error
+          )
+        );
+    }
 
     if (networkStore.rpc) {
       liveStore.start(networkStore.rpc, receivedAddressString);

--- a/src/index.css
+++ b/src/index.css
@@ -72,8 +72,17 @@
 html,
 body {
   background-color: var(--primary-bg);
-  /*margin: 0;*/
   height: 100%;
+  font-family:
+    system-ui,
+    -apple-system,
+    "Segoe UI",
+    Roboto,
+    "Helvetica Neue",
+    Arial,
+    sans-serif;
+  line-height: 1.4;
+  color: var(--text-primary);
 }
 
 #root {

--- a/src/index.css
+++ b/src/index.css
@@ -83,6 +83,7 @@ body {
     sans-serif;
   line-height: 1.4;
   color: var(--text-primary);
+  touch-action: manipulation;
 }
 
 #root {

--- a/src/service/block-processor-service.ts
+++ b/src/service/block-processor-service.ts
@@ -308,10 +308,7 @@ export class BlockProcessorService extends EventEmitter<{
    */
   private shouldProcessBroadcasts(): boolean {
     try {
-      const broadcastStore = useBroadcastStore.getState();
-      return (
-        broadcastStore.isBroadcastMode && broadcastStore.channels.length > 0
-      );
+      return useBroadcastStore.getState().shouldProcessBroadcasts();
     } catch (error) {
       console.error("Error checking broadcast status:", error);
       return false;

--- a/src/store/broadcast.store.ts
+++ b/src/store/broadcast.store.ts
@@ -86,6 +86,8 @@ interface BroadcastState {
   setSelectedParticipant: (
     participant: { address: string; nickname?: string } | null
   ) => void;
+
+  shouldProcessBroadcasts: () => boolean;
 }
 
 export const useBroadcastStore = create<BroadcastState>((set, get) => ({
@@ -364,5 +366,11 @@ export const useBroadcastStore = create<BroadcastState>((set, get) => ({
     participant: { address: string; nickname?: string } | null
   ) => {
     set({ selectedParticipant: participant });
+  },
+
+  shouldProcessBroadcasts: () => {
+    const isBroadcastEnabled =
+      useFeatureFlagsStore.getState().flags[FeatureFlags.BROADCAST];
+    return isBroadcastEnabled && get().channels.length > 0;
   },
 }));

--- a/src/store/featureflag.store.ts
+++ b/src/store/featureflag.store.ts
@@ -39,7 +39,7 @@ const featureFlips: FeatureFlips = {
   },
   [FeatureFlags.BROADCAST]: {
     label: "Broadcasts - Beta Version",
-    desc: `Unencrypted open messages.\nCurrently live messages only, no storage.\nReminder: Broadcasts are unencrypted.`,
+    desc: `Unencrypted open messages.\nLive messages only, no storage.\nReminder: Broadcasts are unencrypted.`,
     icon: Radio,
   },
 };

--- a/src/store/ui.store.ts
+++ b/src/store/ui.store.ts
@@ -60,6 +60,10 @@ type UiState = {
   // QR scanner state
   qrScannerCallback: ((data: string) => void) | null;
   setQrScannerCallback: (callback: ((data: string) => void) | null) => void;
+
+  // Delete wallet modal state
+  pendingDeleteWalletId: string | null;
+  setPendingDeleteWalletId: (id: string | null) => void;
 };
 
 // Get initial theme from localStorage or default to system
@@ -215,4 +219,8 @@ export const useUiStore = create<UiState>()((set, get) => ({
   // QR scanner state
   qrScannerCallback: null,
   setQrScannerCallback: (callback) => set({ qrScannerCallback: callback }),
+
+  // Delete wallet state
+  pendingDeleteWalletId: null,
+  setPendingDeleteWalletId: (id) => set({ pendingDeleteWalletId: id }),
 }));


### PR DESCRIPTION
## what?
refactor of global style and fonts

- alter mode selection (bcast and Dms): if only 2 modes enabled (current max)  that just instant switch with a toast
- fix misc styling bugs
- introduce a 'delete' wallet modal. reason: mobiles didn't respect the window alter and delete does not show
- alter delete all messages and give a sub pane in settings modal
- alter payment popup on mobile to be full width and correct size
- adjust broadcasts so they init on wallet load (lazy) so we can listen for them as long as the app is open
- adjusts the way we prevent mobile zoom  