### PR TITLE
Feat/markdown rendering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "react-router": "7.12.0",
         "react-markdown": "^10.1.0",
         "rehype-sanitize": "^6.0.0",
+        "remark-breaks": "^4.0.0",
         "tauri-plugin-app-events-api": "0.2.0",
         "uuid": "11.1.0",
         "zustand": "5.0.5"
@@ -8341,6 +8342,34 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/mdast-util-from-markdown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.2.tgz",
@@ -8419,6 +8448,20 @@
         "devlop": "^1.0.0",
         "mdast-util-from-markdown": "^2.0.0",
         "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-newline-to-break": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-newline-to-break/-/mdast-util-newline-to-break-2.0.0.tgz",
+      "integrity": "sha512-MbgeFca0hLYIEx/2zGsszCSEJJ1JSCdiY5xQxRcLDDGa8EPvlLPupJ4DSajbMPAnC0je8jfb9TiUATnxxrHUog==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-find-and-replace": "^3.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -10971,6 +11014,21 @@
       "dependencies": {
         "@types/hast": "^3.0.0",
         "hast-util-sanitize": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-breaks": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/remark-breaks/-/remark-breaks-4.0.0.tgz",
+      "integrity": "sha512-IjEjJOkH4FuJvHZVIW0QCDWxcG96kCq7An/KVH2NfJe6rKZU2AsHeB3OEjPNRxi4QC34Xdx7I2KGYn6IpT7gxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-newline-to-break": "^2.0.0",
+        "unified": "^11.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,8 +26,8 @@
         "qrcode": "1.5.4",
         "react": "19.1.0",
         "react-dom": "19.1.0",
-        "react-router": "7.12.0",
         "react-markdown": "10.1.0",
+        "react-router": "7.12.0",
         "remark-breaks": "4.0.0",
         "tauri-plugin-app-events-api": "0.2.0",
         "uuid": "11.1.0",
@@ -7047,21 +7047,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/hast-util-sanitize": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/hast-util-sanitize/-/hast-util-sanitize-5.0.2.tgz",
-      "integrity": "sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "@ungap/structured-clone": "^1.0.0",
-        "unist-util-position": "^5.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/hast-util-to-jsx-runtime": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
@@ -7806,10 +7791,6 @@
     "node_modules/jsqr": {
       "version": "1.4.0",
       "license": "Apache-2.0"
-    },
-    "node_modules/kasia": {
-      "resolved": "",
-      "link": true
     },
     "node_modules/kaspa-wasm": {
       "resolved": "wasm",
@@ -11005,20 +10986,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/rehype-sanitize": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/rehype-sanitize/-/rehype-sanitize-6.0.0.tgz",
-      "integrity": "sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "hast-util-sanitize": "^5.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/remark-breaks": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/remark-breaks/-/remark-breaks-4.0.0.tgz",
@@ -13341,8 +13308,7 @@
       "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
-        "@tauri-apps/api": "^2.8.0",
-        "kasia": "file:../.."
+        "@tauri-apps/api": "^2.8.0"
       },
       "devDependencies": {
         "@rollup/plugin-typescript": "^12.0.0",
@@ -13572,7 +13538,7 @@
     },
     "wasm": {
       "name": "kaspa-wasm",
-      "version": "1.0.1",
+      "version": "1.1.0-rc.2",
       "license": "ISC"
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,9 +27,8 @@
         "react": "19.1.0",
         "react-dom": "19.1.0",
         "react-router": "7.12.0",
-        "react-markdown": "^10.1.0",
-        "rehype-sanitize": "^6.0.0",
-        "remark-breaks": "^4.0.0",
+        "react-markdown": "10.1.0",
+        "remark-breaks": "4.0.0",
         "tauri-plugin-app-events-api": "0.2.0",
         "uuid": "11.1.0",
         "zustand": "5.0.5"
@@ -7048,6 +7047,21 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-sanitize": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-sanitize/-/hast-util-sanitize-5.0.2.tgz",
+      "integrity": "sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "unist-util-position": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-to-jsx-runtime": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
@@ -10989,6 +11003,20 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/rehype-sanitize": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-sanitize/-/rehype-sanitize-6.0.0.tgz",
+      "integrity": "sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-sanitize": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/remark-breaks": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,8 @@
         "react": "19.1.0",
         "react-dom": "19.1.0",
         "react-router": "7.12.0",
+        "react-markdown": "^10.1.0",
+        "rehype-sanitize": "^6.0.0",
         "tauri-plugin-app-events-api": "0.2.0",
         "uuid": "11.1.0",
         "zustand": "5.0.5"
@@ -4156,6 +4158,15 @@
         "@types/deep-eql": "*"
       }
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
+      "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "dev": true,
@@ -4165,9 +4176,42 @@
       "version": "1.0.8",
       "license": "MIT"
     },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -4190,7 +4234,6 @@
     },
     "node_modules/@types/react": {
       "version": "19.1.0",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -4212,6 +4255,12 @@
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
       "license": "MIT"
     },
     "node_modules/@types/uuid": {
@@ -4437,6 +4486,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       }
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "license": "ISC"
     },
     "node_modules/@vitejs/plugin-react-swc": {
       "version": "4.1.0",
@@ -4845,6 +4900,16 @@
         "@babel/types": "^7.26.0"
       }
     },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "dev": true,
@@ -5070,6 +5135,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chai": {
       "version": "5.2.1",
       "dev": true,
@@ -5098,6 +5173,46 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/check-error": {
@@ -5186,6 +5301,16 @@
       "integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/commander": {
       "version": "11.1.0",
@@ -5539,7 +5664,6 @@
     },
     "node_modules/csstype": {
       "version": "3.1.3",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/data-view-buffer": {
@@ -5592,7 +5716,6 @@
     },
     "node_modules/debug": {
       "version": "4.4.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -5611,6 +5734,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.2.0.tgz",
+      "integrity": "sha512-c6fcElNV6ShtZXmsgNgFFV5tVX2PaV4g+MOAkb8eXHvn6sryJBrZa9r0zV6+dtTyoCKxtDy5tyQ5ZwQuidtd+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/deep-eql": {
@@ -5710,7 +5846,6 @@
     },
     "node_modules/dequal": {
       "version": "2.0.3",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -5726,6 +5861,19 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/dijkstrajs": {
@@ -6232,6 +6380,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "2.0.2",
       "dev": true,
@@ -6256,6 +6414,12 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -6883,6 +7047,61 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-sanitize": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-sanitize/-/hast-util-sanitize-5.0.2.tgz",
+      "integrity": "sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "unist-util-position": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hermes-estree": {
       "version": "0.25.1",
       "dev": true,
@@ -6894,6 +7113,16 @@
       "license": "MIT",
       "dependencies": {
         "hermes-estree": "0.25.1"
+      }
+    },
+    "node_modules/html-url-attributes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+      "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/husky": {
@@ -6959,6 +7188,12 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+      "license": "MIT"
+    },
     "node_modules/internal-slot": {
       "version": "1.1.0",
       "dev": true,
@@ -6970,6 +7205,30 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-array-buffer": {
@@ -7091,6 +7350,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-docker": {
       "version": "3.0.0",
       "dev": true,
@@ -7160,6 +7429,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-inside-container": {
@@ -7237,6 +7516,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-regex": {
@@ -7996,6 +8287,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/loupe": {
       "version": "3.2.0",
       "dev": true,
@@ -8040,6 +8341,159 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.2.tgz",
+      "integrity": "sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdn-data": {
       "version": "2.12.2",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
@@ -8056,6 +8510,448 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -8149,7 +9045,6 @@
     },
     "node_modules/ms": {
       "version": "2.1.3",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -8380,6 +9275,31 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -9790,6 +10710,16 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/property-information": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "dev": true,
@@ -9872,6 +10802,33 @@
       "version": "17.0.2",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-markdown": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
+      "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "html-url-attributes": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18",
+        "react": ">=18"
+      }
     },
     "node_modules/react-router": {
       "version": "7.12.0",
@@ -10004,6 +10961,53 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/rehype-sanitize": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-sanitize/-/rehype-sanitize-6.0.0.tgz",
+      "integrity": "sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-sanitize": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/require-directory": {
@@ -10445,6 +11449,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "dev": true,
@@ -10558,6 +11572,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/stringify-object": {
       "version": "3.3.0",
       "dev": true,
@@ -10615,6 +11643,24 @@
       "version": "9.0.1",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.14"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
+      }
     },
     "node_modules/stylehacks": {
       "version": "7.0.7",
@@ -10874,6 +11920,26 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/ts-api-utils": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
@@ -11095,6 +12161,25 @@
         "node": ">=4"
       }
     },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/unique-string": {
       "version": "2.0.0",
       "dev": true,
@@ -11104,6 +12189,74 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
+      "integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/universalify": {
@@ -11176,6 +12329,34 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/esm/bin/uuid"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/vite": {
@@ -12086,6 +13267,16 @@
         "use-sync-external-store": {
           "optional": true
         }
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "vendors/tauri-plugin-biometry": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7048,21 +7048,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/hast-util-sanitize": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/hast-util-sanitize/-/hast-util-sanitize-5.0.2.tgz",
-      "integrity": "sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "@ungap/structured-clone": "^1.0.0",
-        "unist-util-position": "^5.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/hast-util-to-jsx-runtime": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
@@ -11004,20 +10989,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/rehype-sanitize": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/rehype-sanitize/-/rehype-sanitize-6.0.0.tgz",
-      "integrity": "sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "hast-util-sanitize": "^5.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/remark-breaks": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,8 @@
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-router": "7.12.0",
+    "react-markdown": "^10.1.0",
+    "rehype-sanitize": "^6.0.0",
     "tauri-plugin-app-events-api": "0.2.0",
     "uuid": "11.1.0",
     "zustand": "5.0.5"

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "react-router": "7.12.0",
     "react-markdown": "^10.1.0",
     "rehype-sanitize": "^6.0.0",
+    "remark-breaks": "^4.0.0",
     "tauri-plugin-app-events-api": "0.2.0",
     "uuid": "11.1.0",
     "zustand": "5.0.5"

--- a/package.json
+++ b/package.json
@@ -41,10 +41,9 @@
     "qrcode": "1.5.4",
     "react": "19.1.0",
     "react-dom": "19.1.0",
+    "react-markdown": "10.1.0",
     "react-router": "7.12.0",
-    "react-markdown": "^10.1.0",
-    "rehype-sanitize": "^6.0.0",
-    "remark-breaks": "^4.0.0",
+    "remark-breaks": "4.0.0",
     "tauri-plugin-app-events-api": "0.2.0",
     "uuid": "11.1.0",
     "zustand": "5.0.5"

--- a/src/components/MessagesPane/Broadcasts/BroadcastDisplay.tsx
+++ b/src/components/MessagesPane/Broadcasts/BroadcastDisplay.tsx
@@ -114,6 +114,7 @@ export const BroadcastDisplay: FC<BroadcastDisplayProps> = ({
         <MessageContent
           content={message.content}
           isDecrypting={false}
+          isBroadcast={true}
           isOutgoing={isOutgoing}
         />
         {renderTimestamp()}

--- a/src/components/MessagesPane/Composing/Broadcast/BroadcastComposer.tsx
+++ b/src/components/MessagesPane/Composing/Broadcast/BroadcastComposer.tsx
@@ -11,6 +11,11 @@ import { MessageInput } from "../Utilities/MessageInput";
 import { FeeDisplay } from "../Utilities/FeeDisplay";
 import { useFeeEstimate } from "../../../../hooks/MessageComposer/useFeeEstimate";
 import { useIsMobile } from "../../../../hooks/useIsMobile";
+import {
+  useFeatureFlagsStore,
+  FeatureFlags,
+} from "../../../../store/featureflag.store";
+import { MARKDOWN_PREFIX } from "../../../../config/constants";
 
 export const BroadcastComposer = ({ channelName }: { channelName: string }) => {
   const setDraft = useComposerStore((s: ComposerState) => s.setDraft);
@@ -25,6 +30,9 @@ export const BroadcastComposer = ({ channelName }: { channelName: string }) => {
   const { sendBroadcast } = useBroadcastComposer(channelName);
   const messageInputRef = useRef<HTMLTextAreaElement | null>(null);
   const isMobile = useIsMobile();
+
+  const { flags } = useFeatureFlagsStore();
+  const markdownEnabled = flags[FeatureFlags.MARKDOWN];
 
   // readines check
   const canBroadcast = !!channelName && !!sendBroadcast;
@@ -71,7 +79,13 @@ export const BroadcastComposer = ({ channelName }: { channelName: string }) => {
         <div className="relative flex items-center">
           <MessageInput
             ref={messageInputRef}
-            value={canBroadcast ? draft : ""}
+            value={
+              canBroadcast
+                ? markdownEnabled && draft.startsWith(MARKDOWN_PREFIX)
+                  ? draft.slice(MARKDOWN_PREFIX.length)
+                  : draft
+                : ""
+            }
             onChange={handleDraftChange}
             onSend={onSend}
             onDragOver={false}

--- a/src/components/MessagesPane/Composing/Directs/DirectComposer.tsx
+++ b/src/components/MessagesPane/Composing/Directs/DirectComposer.tsx
@@ -18,7 +18,10 @@ import { FeeDisplay } from "../Utilities/FeeDisplay";
 import { useMessagingStore } from "../../../../store/messaging.store";
 import { useFeeEstimate } from "../../../../hooks/MessageComposer/useFeeEstimate";
 import { toast } from "../../../../utils/toast-helper";
-import { MAX_CHAT_INPUT_CHAR } from "../../../../config/constants";
+import {
+  MAX_CHAT_INPUT_CHAR,
+  MARKDOWN_PREFIX,
+} from "../../../../config/constants";
 import { cameraPermissionService } from "../../../../service/camera-permission-service";
 import { useIsMobile } from "../../../../hooks/useIsMobile";
 import {
@@ -40,6 +43,10 @@ export const DirectComposer = ({ recipient }: { recipient?: string }) => {
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const cameraInputRef = useRef<HTMLInputElement | null>(null);
   const isMobile = useIsMobile();
+
+  const { flags } = useFeatureFlagsStore();
+  const cameraEnabled = flags[FeatureFlags.ENABLED_CAMERA];
+  const markdownEnabled = flags[FeatureFlags.MARKDOWN];
 
   const feeState = useFeeEstimate({
     toSelf: true,
@@ -63,10 +70,6 @@ export const DirectComposer = ({ recipient }: { recipient?: string }) => {
     !!conversation &&
     (conversation.status === "active" ||
       (conversation.status === "pending" && conversation.initiatedByMe));
-
-  // Check if camera feature is enabled
-  const { flags } = useFeatureFlagsStore();
-  const cameraEnabled = flags[FeatureFlags.ENABLED_CAMERA];
 
   const guardReady = () => {
     if (!canCompose) {
@@ -219,7 +222,13 @@ export const DirectComposer = ({ recipient }: { recipient?: string }) => {
 
           <MessageInput
             ref={messageInputRef}
-            value={canCompose ? draft : ""}
+            value={
+              canCompose
+                ? markdownEnabled && draft.startsWith(MARKDOWN_PREFIX)
+                  ? draft.slice(MARKDOWN_PREFIX.length)
+                  : draft
+                : ""
+            }
             onChange={handleDraftChange}
             onDragOver={isDragOver}
             onSend={onSend}

--- a/src/components/MessagesPane/Composing/Utilities/InputBasic.tsx
+++ b/src/components/MessagesPane/Composing/Utilities/InputBasic.tsx
@@ -52,9 +52,9 @@ export const InputBasic = forwardRef<HTMLTextAreaElement, InputBasicProps>(
     const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
       let newValue = e.target.value;
 
-      // add markdown prefix if markdown is enabled
+      // add markdown prefix if markdown is enabled and there's real content
       if (markdownEnabled) {
-        newValue = MARKDOWN_PREFIX + newValue;
+        newValue = newValue.trim().length > 0 ? MARKDOWN_PREFIX + newValue : "";
       }
 
       onChange(newValue);

--- a/src/components/MessagesPane/Composing/Utilities/InputBasic.tsx
+++ b/src/components/MessagesPane/Composing/Utilities/InputBasic.tsx
@@ -6,6 +6,8 @@ import {
   MESSAGE_COMPOSER_MAX_HEIGHT,
 } from "../../../../config/constants";
 import { MAX_CHAT_INPUT_CHAR } from "../../../../config/constants";
+import { useFeatureFlagsStore } from "../../../../store/featureflag.store";
+import { MARKDOWN_PREFIX } from "../../../../config/constants";
 
 interface InputBasicProps {
   value: string;
@@ -43,8 +45,19 @@ export const InputBasic = forwardRef<HTMLTextAreaElement, InputBasicProps>(
     const [showScroll, setShowScroll] = useState(false);
     const isMobile = useIsMobile();
 
+    const markdownEnabled = useFeatureFlagsStore(
+      (state) => state.flags.markdown
+    );
+
     const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-      onChange(e.target.value);
+      let newValue = e.target.value;
+
+      // add markdown prefix if markdown is enabled
+      if (markdownEnabled) {
+        newValue = MARKDOWN_PREFIX + newValue;
+      }
+
+      onChange(newValue);
 
       // auto-resize logic - measure with minimal height
       const originalHeight = e.target.style.height;

--- a/src/components/MessagesPane/Utilities/Content/MarkdownRenderer.tsx
+++ b/src/components/MessagesPane/Utilities/Content/MarkdownRenderer.tsx
@@ -38,7 +38,11 @@ export const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
     <ReactMarkdown
       remarkPlugins={[remarkBreaks]}
       components={{
-        a: ({ href, children, ...props }) =>
+        a: ({
+          href,
+          children,
+          ...props
+        }: React.AnchorHTMLAttributes<HTMLAnchorElement>) =>
           enableMdLinks ? (
             isSafeHref(href) ? (
               <a
@@ -60,16 +64,21 @@ export const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
               </a>
             ) : (
               <span {...props}>
-                UNSAFE LINK | Link Text: {children} | Link: {href}
+                Kasia Safety Guard - Not Standard Link | Link Text: {children} |
+                Link: {href}
               </span>
             )
           ) : (
             <span {...props}>
-              KASIA PERMISSION - Links Not Enabled | Link Text: {children} |
+              Kasia Safety Guard - Links Not Enabled | Link Text: {children} |
               Link: {href}
             </span>
           ),
-        img: ({ src, alt, ...props }) =>
+        img: ({
+          src,
+          alt,
+          ...props
+        }: React.ImgHTMLAttributes<HTMLImageElement>) =>
           enableMdImages ? (
             <img src={src} alt={alt} {...props} />
           ) : (

--- a/src/components/MessagesPane/Utilities/Content/MarkdownRenderer.tsx
+++ b/src/components/MessagesPane/Utilities/Content/MarkdownRenderer.tsx
@@ -3,10 +3,14 @@ import ReactMarkdown from "react-markdown";
 import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
 import remarkBreaks from "remark-breaks";
 
-// extend default schema to ensure br tags are allowed
+// extend default schema to ensure br tags are allowed and links can open in new tabs
 const sanitizeSchema = {
   ...defaultSchema,
   tagNames: [...(defaultSchema.tagNames || []), "br"],
+  attributes: {
+    ...defaultSchema.attributes,
+    a: [...(defaultSchema.attributes?.a || []), "target", "rel"],
+  },
 };
 
 interface MarkdownRendererProps {
@@ -16,10 +20,17 @@ interface MarkdownRendererProps {
 export const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
   content,
 }) => (
-  <div className="prose-sm [&_blockquote]:border-l-2 [&_blockquote]:border-current [&_blockquote]:pl-2 [&_blockquote]:opacity-80 [&_code]:rounded [&_code]:bg-black/10 [&_code]:px-1 [&_h1]:text-xl [&_h1]:font-bold [&_h2]:text-lg [&_h2]:font-bold [&_h3]:text-base [&_h3]:font-bold [&_h4]:font-bold [&_ol]:list-decimal [&_ol]:pl-4 [&_pre]:rounded [&_pre]:bg-black/10 [&_pre]:p-2 [&_ul]:list-disc [&_ul]:pl-4">
+  <div className="prose-sm [&_a]:text-blue-400 [&_a]:underline [&_a]:hover:text-blue-300 [&_blockquote]:border-l-2 [&_blockquote]:border-current [&_blockquote]:pl-2 [&_blockquote]:opacity-80 [&_code]:rounded [&_code]:bg-black/10 [&_code]:px-1 [&_h1]:text-xl [&_h1]:font-bold [&_h2]:text-lg [&_h2]:font-bold [&_h3]:text-base [&_h3]:font-bold [&_h4]:font-bold [&_ol]:list-decimal [&_ol]:pl-4 [&_pre]:rounded [&_pre]:bg-black/10 [&_pre]:p-2 [&_ul]:list-disc [&_ul]:pl-4">
     <ReactMarkdown
       remarkPlugins={[remarkBreaks]}
       rehypePlugins={[[rehypeSanitize, sanitizeSchema]]}
+      components={{
+        a: ({ href, children, ...props }) => (
+          <a href={href} target="_blank" rel="noopener noreferrer" {...props}>
+            {children}
+          </a>
+        ),
+      }}
     >
       {content}
     </ReactMarkdown>

--- a/src/components/MessagesPane/Utilities/Content/MarkdownRenderer.tsx
+++ b/src/components/MessagesPane/Utilities/Content/MarkdownRenderer.tsx
@@ -1,35 +1,55 @@
 import React from "react";
 import ReactMarkdown from "react-markdown";
-import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
 import remarkBreaks from "remark-breaks";
-
-// extend default schema to ensure br tags are allowed and links can open in new tabs
-const sanitizeSchema = {
-  ...defaultSchema,
-  tagNames: [...(defaultSchema.tagNames || []), "br"],
-  attributes: {
-    ...defaultSchema.attributes,
-    a: [...(defaultSchema.attributes?.a || []), "target", "rel"],
-  },
-};
 
 interface MarkdownRendererProps {
   content: string;
+  enableMdLinks?: boolean;
+  enableMdImages?: boolean;
 }
 
 export const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
   content,
+  enableMdLinks = false,
+  enableMdImages = false,
 }) => (
   <div className="prose-sm [&_a]:text-blue-400 [&_a]:underline [&_a]:hover:text-blue-300 [&_blockquote]:border-l-2 [&_blockquote]:border-current [&_blockquote]:pl-2 [&_blockquote]:opacity-80 [&_code]:rounded [&_code]:bg-black/10 [&_code]:px-1 [&_h1]:text-xl [&_h1]:font-bold [&_h2]:text-lg [&_h2]:font-bold [&_h3]:text-base [&_h3]:font-bold [&_h4]:font-bold [&_ol]:list-decimal [&_ol]:pl-4 [&_pre]:rounded [&_pre]:bg-black/10 [&_pre]:p-2 [&_ul]:list-disc [&_ul]:pl-4">
     <ReactMarkdown
       remarkPlugins={[remarkBreaks]}
-      rehypePlugins={[[rehypeSanitize, sanitizeSchema]]}
       components={{
-        a: ({ href, children, ...props }) => (
-          <a href={href} target="_blank" rel="noopener noreferrer" {...props}>
-            {children}
-          </a>
-        ),
+        a: ({ href, children, ...props }) =>
+          enableMdLinks ? (
+            <a
+              href={href}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={(e) => {
+                if (
+                  !confirm(
+                    `You are navigating away from Kasia to ${href}. Continue?`
+                  )
+                ) {
+                  e.preventDefault();
+                }
+              }}
+              {...props}
+            >
+              {children}
+            </a>
+          ) : (
+            <span {...props}>
+              KASIA PERMISSION - Links Not Enabled | Link Text: {children} |
+              Link: {href}
+            </span>
+          ),
+        img: ({ src, alt, ...props }) =>
+          enableMdImages ? (
+            <img src={src} alt={alt} {...props} />
+          ) : (
+            <span className="text-gray-500 italic" {...props}>
+              [KASIA PERMISSION - Image Links Not Enabled: {src}]
+            </span>
+          ),
       }}
     >
       {content}

--- a/src/components/MessagesPane/Utilities/Content/MarkdownRenderer.tsx
+++ b/src/components/MessagesPane/Utilities/Content/MarkdownRenderer.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import ReactMarkdown from "react-markdown";
 import remarkBreaks from "remark-breaks";
+// NOTE: In its current vanilla form, our use of react-markdown is safe from XSS attack
+// If adding more plugins or raw HTML support, add rehype-sanitize or find a way to sanitize properly
 
 interface MarkdownRendererProps {
   content: string;

--- a/src/components/MessagesPane/Utilities/Content/MarkdownRenderer.tsx
+++ b/src/components/MessagesPane/Utilities/Content/MarkdownRenderer.tsx
@@ -10,6 +10,25 @@ interface MarkdownRendererProps {
   enableMdImages?: boolean;
 }
 
+const isSafeHref = (href?: string) => {
+  if (!href) return false;
+  const normalized = href.trim().toLowerCase();
+  return (
+    normalized.startsWith("http://") ||
+    normalized.startsWith("https://") ||
+    normalized.startsWith("mailto:") ||
+    normalized.startsWith("www.")
+  );
+};
+
+const normalizeHref = (href?: string) => {
+  if (!href) return undefined;
+  const trimmed = href.trim();
+  return trimmed.toLowerCase().startsWith("www.")
+    ? `https://${trimmed}`
+    : trimmed;
+};
+
 export const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
   content,
   enableMdLinks = false,
@@ -21,23 +40,29 @@ export const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
       components={{
         a: ({ href, children, ...props }) =>
           enableMdLinks ? (
-            <a
-              href={href}
-              target="_blank"
-              rel="noopener noreferrer"
-              onClick={(e) => {
-                if (
-                  !confirm(
-                    `You are navigating away from Kasia to ${href}. Continue?`
-                  )
-                ) {
-                  e.preventDefault();
-                }
-              }}
-              {...props}
-            >
-              {children}
-            </a>
+            isSafeHref(href) ? (
+              <a
+                href={normalizeHref(href)}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={(e) => {
+                  if (
+                    !confirm(
+                      `You are navigating away from Kasia to ${normalizeHref(href)}. Continue?`
+                    )
+                  ) {
+                    e.preventDefault();
+                  }
+                }}
+                {...props}
+              >
+                {children}
+              </a>
+            ) : (
+              <span {...props}>
+                UNSAFE LINK | Link Text: {children} | Link: {href}
+              </span>
+            )
           ) : (
             <span {...props}>
               KASIA PERMISSION - Links Not Enabled | Link Text: {children} |

--- a/src/components/MessagesPane/Utilities/Content/MarkdownRenderer.tsx
+++ b/src/components/MessagesPane/Utilities/Content/MarkdownRenderer.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import ReactMarkdown from "react-markdown";
+import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
+import remarkBreaks from "remark-breaks";
+
+// extend default schema to ensure br tags are allowed
+const sanitizeSchema = {
+  ...defaultSchema,
+  tagNames: [...(defaultSchema.tagNames || []), "br"],
+};
+
+interface MarkdownRendererProps {
+  content: string;
+}
+
+export const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
+  content,
+}) => (
+  <div className="prose-sm [&_blockquote]:border-l-2 [&_blockquote]:border-current [&_blockquote]:pl-2 [&_blockquote]:opacity-80 [&_code]:rounded [&_code]:bg-black/10 [&_code]:px-1 [&_h1]:text-xl [&_h1]:font-bold [&_h2]:text-lg [&_h2]:font-bold [&_h3]:text-base [&_h3]:font-bold [&_h4]:font-bold [&_ol]:list-decimal [&_ol]:pl-4 [&_pre]:rounded [&_pre]:bg-black/10 [&_pre]:p-2 [&_ul]:list-disc [&_ul]:pl-4">
+    <ReactMarkdown
+      remarkPlugins={[remarkBreaks]}
+      rehypePlugins={[[rehypeSanitize, sanitizeSchema]]}
+    >
+      {content}
+    </ReactMarkdown>
+  </div>
+);

--- a/src/components/MessagesPane/Utilities/Content/MessageContent.tsx
+++ b/src/components/MessagesPane/Utilities/Content/MessageContent.tsx
@@ -1,9 +1,16 @@
 import { FC, useState, useRef, useEffect } from "react";
 import clsx from "clsx";
 import ReactMarkdown from "react-markdown";
-import rehypeSanitize from "rehype-sanitize";
+import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
+import remarkBreaks from "remark-breaks";
 import { parseMessageForDisplay } from "../../../../utils/message-format";
 import { MARKDOWN_PREFIX } from "../../../../config/constants";
+
+// extend default schema to ensure br tags are allowed
+const sanitizeSchema = {
+  ...defaultSchema,
+  tagNames: [...(defaultSchema.tagNames || []), "br"],
+};
 
 type MessageContentProps = {
   content: string;
@@ -51,9 +58,14 @@ export const MessageContent: FC<MessageContentProps> = ({
       : content;
 
     const renderedContent = isMarkdown ? (
-      <ReactMarkdown rehypePlugins={[rehypeSanitize]}>
-        {displayContent}
-      </ReactMarkdown>
+      <div className="prose-sm [&_blockquote]:border-l-2 [&_blockquote]:border-current [&_blockquote]:pl-2 [&_blockquote]:opacity-80 [&_code]:rounded [&_code]:bg-black/10 [&_code]:px-1 [&_h1]:text-xl [&_h1]:font-bold [&_h2]:text-lg [&_h2]:font-bold [&_h3]:text-base [&_h3]:font-bold [&_h4]:font-bold [&_ol]:list-decimal [&_ol]:pl-4 [&_pre]:rounded [&_pre]:bg-black/10 [&_pre]:p-2 [&_ul]:list-disc [&_ul]:pl-4">
+        <ReactMarkdown
+          remarkPlugins={[remarkBreaks]}
+          rehypePlugins={[[rehypeSanitize, sanitizeSchema]]}
+        >
+          {displayContent}
+        </ReactMarkdown>
+      </div>
     ) : (
       parseMessageForDisplay(displayContent)
     );

--- a/src/components/MessagesPane/Utilities/Content/MessageContent.tsx
+++ b/src/components/MessagesPane/Utilities/Content/MessageContent.tsx
@@ -1,6 +1,9 @@
 import { FC, useState, useRef, useEffect } from "react";
 import clsx from "clsx";
+import ReactMarkdown from "react-markdown";
+import rehypeSanitize from "rehype-sanitize";
 import { parseMessageForDisplay } from "../../../../utils/message-format";
+import { MARKDOWN_PREFIX } from "../../../../config/constants";
 
 type MessageContentProps = {
   content: string;
@@ -39,9 +42,21 @@ export const MessageContent: FC<MessageContentProps> = ({
     );
   }
 
-  // render plain text with newlines as <br /> and \\n as literal text
+  // render content (markdown or plain text) with expand/collapse functionality
   if (typeof content === "string") {
-    const parsedContent = parseMessageForDisplay(content);
+    // check if content starts with markdown flag and process content
+    const isMarkdown = content.startsWith(MARKDOWN_PREFIX);
+    const displayContent = isMarkdown
+      ? content.slice(MARKDOWN_PREFIX.length)
+      : content;
+
+    const renderedContent = isMarkdown ? (
+      <ReactMarkdown rehypePlugins={[rehypeSanitize]}>
+        {displayContent}
+      </ReactMarkdown>
+    ) : (
+      parseMessageForDisplay(displayContent)
+    );
 
     return (
       <div>
@@ -61,7 +76,7 @@ export const MessageContent: FC<MessageContentProps> = ({
                 : "none",
           }}
         >
-          {parsedContent}
+          {renderedContent}
         </div>
 
         {shouldCollapse && (

--- a/src/components/MessagesPane/Utilities/Content/MessageContent.tsx
+++ b/src/components/MessagesPane/Utilities/Content/MessageContent.tsx
@@ -3,21 +3,32 @@ import clsx from "clsx";
 import { parseMessageForDisplay } from "../../../../utils/message-format";
 import { MARKDOWN_PREFIX } from "../../../../config/constants";
 import { MarkdownRenderer } from "./MarkdownRenderer";
+import { useFeatureFlagsStore } from "../../../../store/featureflag.store";
 
 type MessageContentProps = {
   content: string;
   isDecrypting: boolean;
+  isBroadcast?: boolean;
   isOutgoing?: boolean;
 };
 
 export const MessageContent: FC<MessageContentProps> = ({
   content,
   isDecrypting,
+  isBroadcast = false,
   isOutgoing = true,
 }) => {
   const [isExpanded, setIsExpanded] = useState(false);
   const [shouldCollapse, setShouldCollapse] = useState(false);
   const contentRef = useRef<HTMLDivElement>(null);
+
+  const imageLinksEnabled = useFeatureFlagsStore(
+    (state) => state.flags.broadcast_image_links
+  );
+
+  const clickableLinksEnabled = useFeatureFlagsStore(
+    (state) => state.flags.broadcast_links
+  );
 
   // check if content should be collapsed based on line count, length or some combo
   useEffect(() => {
@@ -49,11 +60,15 @@ export const MessageContent: FC<MessageContentProps> = ({
       ? content.slice(MARKDOWN_PREFIX.length)
       : content;
 
-    // preserve multiple consecutive newlines by adding nbsp between consecutive newlines only
-    const formattedContent = displayContent.replace(/\n\n/g, "\n&nbsp;\n");
+    // preserve multiple consecutive newlines by replacing them with non-breaking spaces
+    const formattedContent = displayContent.replace(/\n{2,}/g, "\n\u00A0\n");
 
     const renderedContent = isMarkdown ? (
-      <MarkdownRenderer content={formattedContent} />
+      <MarkdownRenderer
+        content={formattedContent}
+        enableMdLinks={clickableLinksEnabled || !isBroadcast}
+        enableMdImages={imageLinksEnabled || !isBroadcast}
+      />
     ) : (
       parseMessageForDisplay(displayContent)
     );

--- a/src/components/MessagesPane/Utilities/Content/MessageContent.tsx
+++ b/src/components/MessagesPane/Utilities/Content/MessageContent.tsx
@@ -1,16 +1,8 @@
 import { FC, useState, useRef, useEffect } from "react";
 import clsx from "clsx";
-import ReactMarkdown from "react-markdown";
-import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
-import remarkBreaks from "remark-breaks";
 import { parseMessageForDisplay } from "../../../../utils/message-format";
 import { MARKDOWN_PREFIX } from "../../../../config/constants";
-
-// extend default schema to ensure br tags are allowed
-const sanitizeSchema = {
-  ...defaultSchema,
-  tagNames: [...(defaultSchema.tagNames || []), "br"],
-};
+import { MarkdownRenderer } from "./MarkdownRenderer";
 
 type MessageContentProps = {
   content: string;
@@ -49,7 +41,7 @@ export const MessageContent: FC<MessageContentProps> = ({
     );
   }
 
-  // render content (markdown or plain text) with expand/collapse functionality
+  // render content (markdown or plain text)
   if (typeof content === "string") {
     // check if content starts with markdown flag and process content
     const isMarkdown = content.startsWith(MARKDOWN_PREFIX);
@@ -57,15 +49,11 @@ export const MessageContent: FC<MessageContentProps> = ({
       ? content.slice(MARKDOWN_PREFIX.length)
       : content;
 
+    // preserve multiple consecutive newlines by adding nbsp between consecutive newlines only
+    const formattedContent = displayContent.replace(/\n\n/g, "\n&nbsp;\n");
+
     const renderedContent = isMarkdown ? (
-      <div className="prose-sm [&_blockquote]:border-l-2 [&_blockquote]:border-current [&_blockquote]:pl-2 [&_blockquote]:opacity-80 [&_code]:rounded [&_code]:bg-black/10 [&_code]:px-1 [&_h1]:text-xl [&_h1]:font-bold [&_h2]:text-lg [&_h2]:font-bold [&_h3]:text-base [&_h3]:font-bold [&_h4]:font-bold [&_ol]:list-decimal [&_ol]:pl-4 [&_pre]:rounded [&_pre]:bg-black/10 [&_pre]:p-2 [&_ul]:list-disc [&_ul]:pl-4">
-        <ReactMarkdown
-          remarkPlugins={[remarkBreaks]}
-          rehypePlugins={[[rehypeSanitize, sanitizeSchema]]}
-        >
-          {displayContent}
-        </ReactMarkdown>
-      </div>
+      <MarkdownRenderer content={formattedContent} />
     ) : (
       parseMessageForDisplay(displayContent)
     );

--- a/src/components/Modals/SettingsModal.tsx
+++ b/src/components/Modals/SettingsModal.tsx
@@ -982,61 +982,180 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
             {activeTab === "extras" && (
               <div className="mt-3 space-y-6 sm:mt-0">
                 <h3 className="mb-4 text-lg font-medium">Features</h3>
+                <div className="mt-3 space-y-6 overflow-hidden sm:mt-0">
+                  <h3 className="mb-4 text-lg font-medium">Extra</h3>
 
-                <div className="space-y-2">
-                  {/* Warning */}
-                  <WarningBlock title="Warning">
-                    Some of these features are in beta or expose you to external
-                    content
-                  </WarningBlock>
-                  {Object.entries(flips).map(([flagKey, item]) => (
-                    <div
-                      key={flagKey}
-                      onClick={() =>
-                        setFlag(
-                          flagKey as FeatureFlags,
-                          !flags[flagKey as FeatureFlags]
-                        )
-                      }
-                      className="border-primary-border bg-primary-bg hover:bg-primary-bg/50 my-2 cursor-pointer rounded-2xl border p-4 transition-colors"
-                    >
-                      <div className="flex items-center justify-between">
-                        <div className="flex-1">
-                          <div className="mb-1 text-sm font-semibold">
-                            {item.label}
+                  <div className="space-y-2">
+                    {/* Warning */}
+                    <WarningBlock title="Warning">
+                      Some of these features are in beta or expose you to
+                      external content
+                    </WarningBlock>
+                    {Object.entries(flips).map(([flagKey, item]) => (
+                      <div
+                        key={flagKey}
+                        onClick={() =>
+                          setFlag(
+                            flagKey as FeatureFlags,
+                            !flags[flagKey as FeatureFlags]
+                          )
+                        }
+                        className="border-primary-border bg-primary-bg hover:bg-primary-bg/50 my-2 cursor-pointer rounded-2xl border p-4 transition-colors"
+                      >
+                        <div className="flex items-center justify-between">
+                          <div className="flex-1">
+                            <div className="mb-1 text-sm font-semibold">
+                              {item.label}
+                            </div>
+                            <div className="text-xs whitespace-pre-line">
+                              {item.desc}
+                            </div>
                           </div>
-                          <div className="text-xs whitespace-pre-line">
-                            {item.desc}
-                          </div>
-                        </div>
-                        <Switch
-                          checked={flags[flagKey as FeatureFlags] || false}
-                          onChange={(enabled) =>
-                            setFlag(flagKey as FeatureFlags, enabled)
-                          }
-                          className={clsx(
-                            "relative inline-flex h-6 w-11 cursor-pointer items-center rounded-full transition-colors",
-                            {
-                              "bg-kas-secondary":
-                                flags[flagKey as FeatureFlags],
-                              "bg-gray-300": !flags[flagKey as FeatureFlags],
+                          <Switch
+                            checked={flags[flagKey as FeatureFlags] || false}
+                            onChange={(enabled) =>
+                              setFlag(flagKey as FeatureFlags, enabled)
                             }
-                          )}
-                        >
-                          <span
                             className={clsx(
-                              "inline-block h-4 w-4 transform rounded-full bg-white transition-transform",
+                              "relative inline-flex h-6 w-11 cursor-pointer items-center rounded-full transition-colors",
                               {
-                                "translate-x-6": flags[flagKey as FeatureFlags],
-                                "translate-x-1":
-                                  !flags[flagKey as FeatureFlags],
+                                "bg-kas-secondary":
+                                  flags[flagKey as FeatureFlags],
+                                "bg-gray-300": !flags[flagKey as FeatureFlags],
                               }
                             )}
-                          />
-                        </Switch>
+                          >
+                            <span
+                              className={clsx(
+                                "inline-block h-4 w-4 transform rounded-full bg-white transition-transform",
+                                {
+                                  "translate-x-6":
+                                    flags[flagKey as FeatureFlags],
+                                  "translate-x-1":
+                                    !flags[flagKey as FeatureFlags],
+                                }
+                              )}
+                            />
+                          </Switch>
+                        </div>
                       </div>
-                    </div>
-                  ))}
+                    ))}
+                  </div>
+                  {Object.entries(flips)
+                    .filter(([, item]) => !item.parent) // only render parent flags at top level
+                    .map(([flagKey, item]) => {
+                      const isEnabled = flags[flagKey as FeatureFlags];
+
+                      // find child flags for this parent
+                      const childFlags = Object.entries(flips).filter(
+                        ([, childItem]) => childItem.parent === flagKey
+                      );
+
+                      return (
+                        <div key={flagKey} className="my-2">
+                          {/* Parent Flag */}
+                          <div
+                            onClick={() =>
+                              setFlag(flagKey as FeatureFlags, !isEnabled)
+                            }
+                            className="border-primary-border bg-primary-bg hover:bg-primary-bg/50 cursor-pointer rounded-2xl border p-4 transition-colors"
+                          >
+                            <div className="flex items-center justify-between">
+                              <div className="flex-1">
+                                <div className="mb-1 text-sm font-semibold">
+                                  {item.label}
+                                </div>
+                                <div className="text-muted-foreground text-xs whitespace-pre-line">
+                                  {item.desc}
+                                </div>
+                              </div>
+                              <Switch
+                                checked={isEnabled}
+                                onChange={(enabled) =>
+                                  setFlag(flagKey as FeatureFlags, enabled)
+                                }
+                                className={clsx(
+                                  "relative inline-flex h-6 w-11 cursor-pointer items-center rounded-full transition-colors",
+                                  {
+                                    "bg-kas-secondary": isEnabled,
+                                    "bg-gray-300": !isEnabled,
+                                  }
+                                )}
+                              >
+                                <span
+                                  className={clsx(
+                                    "inline-block h-4 w-4 transform rounded-full bg-white transition-transform",
+                                    {
+                                      "translate-x-6": isEnabled,
+                                      "translate-x-1": !isEnabled,
+                                    }
+                                  )}
+                                />
+                              </Switch>
+                            </div>
+                          </div>
+
+                          {/* Child flags - only show when parent is enabled */}
+                          {isEnabled && childFlags.length > 0 && (
+                            <div className="mt-2 space-y-2 pl-4">
+                              {childFlags.map(([childKey, childItem]) => {
+                                const isChildEnabled =
+                                  flags[childKey as FeatureFlags];
+                                return (
+                                  <div
+                                    key={childKey}
+                                    onClick={() =>
+                                      setFlag(
+                                        childKey as FeatureFlags,
+                                        !isChildEnabled
+                                      )
+                                    }
+                                    className="border-primary-border bg-primary-bg/80 hover:bg-primary-bg/60 cursor-pointer rounded-xl border p-3 transition-colors"
+                                  >
+                                    <div className="flex items-center justify-between">
+                                      <div className="flex-1">
+                                        <div className="text-sm font-medium">
+                                          {childItem.label}
+                                        </div>
+                                        <div className="text-muted-foreground text-xs whitespace-pre-line">
+                                          {childItem.desc}
+                                        </div>
+                                      </div>
+                                      <Switch
+                                        checked={isChildEnabled}
+                                        onChange={(enabled) =>
+                                          setFlag(
+                                            childKey as FeatureFlags,
+                                            enabled
+                                          )
+                                        }
+                                        className={clsx(
+                                          "relative inline-flex h-5 w-9 cursor-pointer items-center rounded-full transition-colors",
+                                          {
+                                            "bg-kas-secondary": isChildEnabled,
+                                            "bg-gray-300": !isChildEnabled,
+                                          }
+                                        )}
+                                      >
+                                        <span
+                                          className={clsx(
+                                            "inline-block h-3 w-3 transform rounded-full bg-white transition-transform",
+                                            {
+                                              "translate-x-5": isChildEnabled,
+                                              "translate-x-1": !isChildEnabled,
+                                            }
+                                          )}
+                                        />
+                                      </Switch>
+                                    </div>
+                                  </div>
+                                );
+                              })}
+                            </div>
+                          )}
+                        </div>
+                      );
+                    })}
                 </div>
               </div>
             )}

--- a/src/components/SideBarPane/Directs/ContactCard.tsx
+++ b/src/components/SideBarPane/Directs/ContactCard.tsx
@@ -3,9 +3,11 @@ import { decodePayload } from "../../../utils/format";
 import { useMessagingStore } from "../../../store/messaging.store";
 import { AvatarHash } from "../../icons/AvatarHash";
 import { PROTOCOL } from "../../../config/protocol";
+import { MARKDOWN_PREFIX } from "../../../config/constants";
 import clsx from "clsx";
 import { Contact } from "../../../store/repository/contact.repository";
 import { getFileTypeFromContent } from "../../../utils/parse-message";
+import { stripMarkdown } from "../../../utils/markdown";
 
 function getMessagePreview(content: string) {
   // check if it's a file or image message
@@ -20,15 +22,29 @@ function getMessagePreview(content: string) {
     }
   }
 
-  // For regular messages, try to decode if it's encrypted
+  let messageContent: string;
   if (content.startsWith(PROTOCOL.prefix.string)) {
     const decoded = decodePayload(content);
-    return decoded
-      ? decoded.slice(0, 40) + (decoded.length > 40 ? "..." : "")
-      : "Encrypted message";
+    if (!decoded) return "Encrypted message";
+    messageContent = decoded;
+  } else {
+    messageContent = content;
   }
 
-  return content.slice(0, 40) + (content.length > 40 ? "..." : "");
+  const isMarkdown = messageContent.startsWith(MARKDOWN_PREFIX);
+  if (isMarkdown) {
+    const processedContent = messageContent.slice(MARKDOWN_PREFIX.length);
+    // strip off the markdown flags, so we can just render the content 'plain' in the preview
+    const plainTextContent = stripMarkdown(processedContent);
+    return (
+      plainTextContent.slice(0, 40) +
+      (plainTextContent.length > 40 ? "..." : "")
+    );
+  }
+
+  return (
+    messageContent.slice(0, 40) + (messageContent.length > 40 ? "..." : "")
+  );
 }
 
 export const ContactCard: FC<{

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -31,6 +31,8 @@ export const MAX_CHAT_INPUT_CHAR = 18000;
 // broadcast channel name length limit, at 36 due to having parity with a uuid char length
 export const MAX_BROADCAST_CHANNEL_NAME = 36;
 
+export const MARKDOWN_PREFIX = "§";
+
 // Triggers a warn in the wallet to withdraw to cold storage.
 // Settings at 30KAS
 export const BALANCE_WARN = BigInt(30 * 100_000_000);

--- a/src/hooks/MessageComposer/useBroadcastComposer.ts
+++ b/src/hooks/MessageComposer/useBroadcastComposer.ts
@@ -1,11 +1,18 @@
 import { useComposerStore } from "../../store/message-composer.store";
 import { useWalletStore } from "../../store/wallet.store";
 import { useBroadcastStore } from "../../store/broadcast.store";
+import {
+  useFeatureFlagsStore,
+  FeatureFlags,
+} from "../../store/featureflag.store";
+import { MARKDOWN_PREFIX } from "../../config/constants";
 import { toast } from "../../utils/toast-helper";
 
 export const useBroadcastComposer = (channelName?: string) => {
   const { sendState, setSendState, clearDraft } = useComposerStore();
   const { addMessage, updateMessageStatus } = useBroadcastStore();
+  const { flags } = useFeatureFlagsStore();
+  const markdownEnabled = flags[FeatureFlags.MARKDOWN];
 
   const draft = useComposerStore((s) =>
     channelName ? s.drafts[channelName] || "" : ""
@@ -34,8 +41,11 @@ export const useBroadcastComposer = (channelName?: string) => {
     try {
       setSendState({ status: "loading" });
 
+      // prepend markdown prefix if markdown is enabled
+      const messageToSend = markdownEnabled ? MARKDOWN_PREFIX + draft : draft;
+
       const txId = await walletStore.sendBroadcastWithContext({
-        message: draft,
+        message: messageToSend,
         channelName: channelName.toLowerCase(),
         priorityFee: useComposerStore.getState().priority,
       });
@@ -46,7 +56,7 @@ export const useBroadcastComposer = (channelName?: string) => {
         id: txId,
         channelName: channelName.toLowerCase(),
         senderAddress: walletStore.address!.toString(),
-        content: draft,
+        content: messageToSend,
         timestamp: new Date(),
         transactionId: txId,
         status: "pending",

--- a/src/hooks/MessageComposer/useBroadcastComposer.ts
+++ b/src/hooks/MessageComposer/useBroadcastComposer.ts
@@ -41,8 +41,7 @@ export const useBroadcastComposer = (channelName?: string) => {
     try {
       setSendState({ status: "loading" });
 
-      // prepend markdown prefix if markdown is enabled
-      const messageToSend = markdownEnabled ? MARKDOWN_PREFIX + draft : draft;
+      const messageToSend = draft;
 
       const txId = await walletStore.sendBroadcastWithContext({
         message: messageToSend,

--- a/src/hooks/MessageComposer/useMessageComposer.ts
+++ b/src/hooks/MessageComposer/useMessageComposer.ts
@@ -1,10 +1,6 @@
 import { useComposerStore } from "../../store/message-composer.store";
 import { useWalletStore } from "../../store/wallet.store";
 import { useMessagingStore } from "../../store/messaging.store";
-import {
-  useFeatureFlagsStore,
-  FeatureFlags,
-} from "../../store/featureflag.store";
 import { MARKDOWN_PREFIX } from "../../config/constants";
 import { Address } from "kaspa-wasm";
 import { toast } from "../../utils/toast-helper";
@@ -24,8 +20,6 @@ export const useMessageComposer = (feeState: FeeState, recipient?: string) => {
     setAttachment,
     clearDraft,
   } = useComposerStore();
-  const { flags } = useFeatureFlagsStore();
-  const markdownEnabled = flags[FeatureFlags.MARKDOWN];
   const draft = useComposerStore((s) =>
     recipient ? s.drafts[recipient] || "" : ""
   );
@@ -90,11 +84,6 @@ export const useMessageComposer = (feeState: FeeState, recipient?: string) => {
     try {
       let messageToSend = draft;
       let fileDataForStorage: FileData | null = null;
-
-      // prepend markdown prefix if markdown is enabled and there's text content
-      if (markdownEnabled && draft && !attachment) {
-        messageToSend = MARKDOWN_PREFIX + draft;
-      }
 
       if (attachment) {
         messageToSend = attachment.content; // always send attachment payload

--- a/src/hooks/MessageComposer/useMessageComposer.ts
+++ b/src/hooks/MessageComposer/useMessageComposer.ts
@@ -1,6 +1,11 @@
 import { useComposerStore } from "../../store/message-composer.store";
 import { useWalletStore } from "../../store/wallet.store";
 import { useMessagingStore } from "../../store/messaging.store";
+import {
+  useFeatureFlagsStore,
+  FeatureFlags,
+} from "../../store/featureflag.store";
+import { MARKDOWN_PREFIX } from "../../config/constants";
 import { Address } from "kaspa-wasm";
 import { toast } from "../../utils/toast-helper";
 import { unknownErrorToErrorLike } from "../../utils/errors";
@@ -19,6 +24,8 @@ export const useMessageComposer = (feeState: FeeState, recipient?: string) => {
     setAttachment,
     clearDraft,
   } = useComposerStore();
+  const { flags } = useFeatureFlagsStore();
+  const markdownEnabled = flags[FeatureFlags.MARKDOWN];
   const draft = useComposerStore((s) =>
     recipient ? s.drafts[recipient] || "" : ""
   );
@@ -83,6 +90,11 @@ export const useMessageComposer = (feeState: FeeState, recipient?: string) => {
     try {
       let messageToSend = draft;
       let fileDataForStorage: FileData | null = null;
+
+      // prepend markdown prefix if markdown is enabled and there's text content
+      if (markdownEnabled && draft && !attachment) {
+        messageToSend = MARKDOWN_PREFIX + draft;
+      }
 
       if (attachment) {
         messageToSend = attachment.content; // always send attachment payload

--- a/src/store/featureflag.store.ts
+++ b/src/store/featureflag.store.ts
@@ -1,11 +1,18 @@
 import { create } from "zustand";
-import { Coins, LucideIcon, Radio, Camera } from "lucide-react";
+import {
+  Coins,
+  LucideIcon,
+  Radio,
+  Camera,
+  MessageSquareText,
+} from "lucide-react";
 import { cameraPermissionService } from "../service/camera-permission-service";
 
 export enum FeatureFlags {
   BROADCAST = "broadcast",
   CUSTOM_FEE = "customfee",
   ENABLED_CAMERA = "enabledcamera",
+  MARKDOWN = "markdown",
 }
 
 export type FeatureFlagsTable = Record<FeatureFlags, boolean>;
@@ -14,6 +21,7 @@ const defaultFeatureFlagsTable: FeatureFlagsTable = {
   [FeatureFlags.BROADCAST]: false,
   [FeatureFlags.CUSTOM_FEE]: false,
   [FeatureFlags.ENABLED_CAMERA]: false,
+  [FeatureFlags.MARKDOWN]: false,
 };
 
 export interface FeatureDescription {
@@ -41,6 +49,11 @@ const featureFlips: FeatureFlips = {
     label: "Broadcasts - Beta Version",
     desc: `Unencrypted open messages.\nLive messages only, no storage.\nReminder: Broadcasts are unencrypted.`,
     icon: Radio,
+  },
+  [FeatureFlags.MARKDOWN]: {
+    label: "Markdown Messages",
+    desc: `Enable markdown formatting for all messages sent.`,
+    icon: MessageSquareText,
   },
 };
 

--- a/src/store/featureflag.store.ts
+++ b/src/store/featureflag.store.ts
@@ -52,7 +52,7 @@ const featureFlips: FeatureFlips = {
   },
   [FeatureFlags.MARKDOWN]: {
     label: "Markdown Messages",
-    desc: `Enable markdown formatting for all messages sent.`,
+    desc: `Enable markdown formatting for all messages.\nReminder: Messages will cost slightly more due to markdown formatting`,
     icon: MessageSquareText,
   },
 };

--- a/src/store/featureflag.store.ts
+++ b/src/store/featureflag.store.ts
@@ -5,11 +5,15 @@ import {
   Radio,
   Camera,
   MessageSquareText,
+  Image,
+  Link,
 } from "lucide-react";
 import { cameraPermissionService } from "../service/camera-permission-service";
 
 export enum FeatureFlags {
   BROADCAST = "broadcast",
+  BROADCAST_IMAGE_LINKS = "broadcast_image_links",
+  BROADCAST_LINKS = "broadcast_links",
   CUSTOM_FEE = "customfee",
   ENABLED_CAMERA = "enabledcamera",
   MARKDOWN = "markdown",
@@ -19,6 +23,8 @@ export type FeatureFlagsTable = Record<FeatureFlags, boolean>;
 
 const defaultFeatureFlagsTable: FeatureFlagsTable = {
   [FeatureFlags.BROADCAST]: false,
+  [FeatureFlags.BROADCAST_IMAGE_LINKS]: false,
+  [FeatureFlags.BROADCAST_LINKS]: false,
   [FeatureFlags.CUSTOM_FEE]: false,
   [FeatureFlags.ENABLED_CAMERA]: false,
   [FeatureFlags.MARKDOWN]: false,
@@ -28,6 +34,7 @@ export interface FeatureDescription {
   label: string;
   desc: string;
   icon: LucideIcon;
+  parent?: FeatureFlags; // if set, this is a child flag rendered under the closet parent up the list
 }
 
 export type FeatureFlips = Record<FeatureFlags, FeatureDescription>;
@@ -40,6 +47,11 @@ const featureFlips: FeatureFlips = {
       "\nNote: Photos are encrypted but sent on chain.",
     icon: Camera,
   },
+  [FeatureFlags.MARKDOWN]: {
+    label: "Send Markdown Messages",
+    desc: `Enable markdown formatting for all outgoing messages.\nReminder: Messages will cost slightly more due to markdown formatting`,
+    icon: MessageSquareText,
+  },
   [FeatureFlags.CUSTOM_FEE]: {
     label: "Custom Priority Fee",
     desc: "Turn on to set custom priority fee in chat.",
@@ -50,10 +62,17 @@ const featureFlips: FeatureFlips = {
     desc: `Unencrypted open messages.\nLive messages only, no storage.\nReminder: Broadcasts are unencrypted.`,
     icon: Radio,
   },
-  [FeatureFlags.MARKDOWN]: {
-    label: "Markdown Messages",
-    desc: `Enable markdown formatting for all messages.\nReminder: Messages will cost slightly more due to markdown formatting`,
-    icon: MessageSquareText,
+  [FeatureFlags.BROADCAST_IMAGE_LINKS]: {
+    label: "Broadcasts - Enable Image Links",
+    desc: "Allow embedded image links to render.\nWarning: This is unfiltered and potentially contains unwanted content.",
+    icon: Image,
+    parent: FeatureFlags.BROADCAST,
+  },
+  [FeatureFlags.BROADCAST_LINKS]: {
+    label: "Broadcasts - Enable Links",
+    desc: "Make markdown links clickable.\nWarning: Links are dangerous if clicked.",
+    icon: Link,
+    parent: FeatureFlags.BROADCAST,
   },
 };
 
@@ -61,8 +80,9 @@ const useFeatureFlagsStore = create<{
   flags: FeatureFlagsTable;
   flips: FeatureFlips;
   setFlag: (key: FeatureFlags, value: boolean) => void;
+  isFlagEnabled: (key: FeatureFlags) => boolean;
 }>((set, get) => {
-  // hydrate features here, else take default value
+  // hydrate from localStorage
   let initialFlags = defaultFeatureFlagsTable;
   try {
     const stored = JSON.parse(
@@ -79,6 +99,16 @@ const useFeatureFlagsStore = create<{
 
     setFlag: (key, value) => {
       const updated = { ...get().flags, [key]: value };
+
+      // if disabling a parent flag, also disable all its children
+      if (!value) {
+        for (const [childKey, childFlip] of Object.entries(featureFlips)) {
+          if (childFlip.parent === key) {
+            updated[childKey as FeatureFlags] = false;
+          }
+        }
+      }
+
       set({ flags: updated });
 
       // clear camera permission if camera feature is disabled
@@ -87,6 +117,15 @@ const useFeatureFlagsStore = create<{
       }
 
       localStorage.setItem("kasia-feature-flags", JSON.stringify(updated));
+    },
+
+    isFlagEnabled: (key) => {
+      const flip = featureFlips[key];
+      // if this flag has a parent, it's only effective if parent is also enabled
+      if (flip.parent) {
+        return get().flags[flip.parent] && get().flags[key];
+      }
+      return get().flags[key];
     },
   };
 });

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -1,0 +1,30 @@
+// strip markdown formatting and return plain text
+export function stripMarkdown(markdown: string): string {
+  return (
+    markdown
+      // remove code blocks
+      .replace(/```[\s\S]*?```/g, "[code block]")
+      .replace(/`[^`\n]+`/g, "[code]")
+      // remove links and images
+      .replace(/!\[([^\]]*)\]\([^)]*\)/g, "$1") // images
+      .replace(/\[([^\]]+)\]\([^)]*\)/g, "$1") // links
+      // remove headers
+      .replace(/^#+\s*/gm, "")
+      // remove bold/italic
+      .replace(/\*\*\*([^*]+)\*\*\*/g, "$1") // bold italic
+      .replace(/\*\*([^*]+)\*\*/g, "$1") // bold
+      .replace(/\*([^*]+)\*/g, "$1") // italic
+      .replace(/__([^_]+)__/g, "$1") // underline bold
+      .replace(/_([^_]+)_/g, "$1") // underline italic
+      // remove strikethrough
+      .replace(/~~([^~]+)~~/g, "$1")
+      // remove blockquotes
+      .replace(/^>\s*/gm, "")
+      // remove list markers
+      .replace(/^[\s]*[-*+]\s+/gm, "")
+      .replace(/^[\s]*\d+\.\s+/gm, "")
+      // clean up extra whitespace
+      .replace(/\n{2,}/g, " ")
+      .trim()
+  );
+}


### PR DESCRIPTION
## What?
adds markdown rendering to messages

by default, all clients will render Markdown messages if they include the `MARKDOWN_PREFIX = "§"`. However, to send markdown messages, you must enable it via a feature flip. This is because of the higher cost etc.

with rendering enabled, broadcasts do not render links or images by default. This must be enabled separately as a sub-feature. In direct messages, links and images are always rendered.

currently we (I) are only planning to support the base CommonMark standard. As I *personally* don't think a chat app needs rich github level markdown features. There is also no UI interface to interactively place markdown or to see the markdown as you write it, maybe this can happen in future versions (item 2 here being of more importance than item 1) .

<img width="741" height="923" alt="image" src="https://github.com/user-attachments/assets/04deb6c3-0353-42de-8fcd-c84dae514d99" />
