### PR TITLE
Feat/direct send status

### DIFF
--- a/src/components/MessagesPane/Directs/DirectDisplay.tsx
+++ b/src/components/MessagesPane/Directs/DirectDisplay.tsx
@@ -127,7 +127,10 @@ export const DirectDisplay: FC<DirectDisplayProps> = ({
             generateBubbleClasses({
               isOutgoing,
               groupPosition,
-              status: event.__type === "message" ? event.status : "confirmed",
+              status:
+                event.__type === "message" || event.__type === "payment"
+                  ? event.status
+                  : "confirmed",
             })
         )}
       >

--- a/src/components/MessagesPane/Directs/DirectDisplay.tsx
+++ b/src/components/MessagesPane/Directs/DirectDisplay.tsx
@@ -127,6 +127,7 @@ export const DirectDisplay: FC<DirectDisplayProps> = ({
             generateBubbleClasses({
               isOutgoing,
               groupPosition,
+              status: event.__type === "message" ? event.status : "confirmed",
             })
         )}
       >

--- a/src/components/MessagesPane/Utilities/Utils/BubbleClassGenerator.tsx
+++ b/src/components/MessagesPane/Utilities/Utils/BubbleClassGenerator.tsx
@@ -1,4 +1,5 @@
 import clsx from "clsx";
+import { TransactionStatus } from "../../../../types/all";
 
 type GroupPosition = "single" | "top" | "middle" | "bottom";
 type BubbleClassOptions = {
@@ -6,7 +7,7 @@ type BubbleClassOptions = {
   groupPosition: GroupPosition;
   className?: string;
   noBubble?: boolean;
-  status?: "pending" | "confirmed" | "failed";
+  status?: TransactionStatus;
   customBorderColor?: string;
 };
 

--- a/src/service/block-processor-service.ts
+++ b/src/service/block-processor-service.ts
@@ -104,6 +104,9 @@ export class BlockProcessorService extends EventEmitter<{
 
       // mark as processed optimistically
       this.processedTransactionIds.add(txId);
+      const parsed = parseKaspaMessagePayload(tx.payload);
+
+      const messageType = parsed.type;
 
       /*
        * Temp hacky solution to mark out pending messages as confirmed
@@ -111,7 +114,6 @@ export class BlockProcessorService extends EventEmitter<{
        * align with broadcast message update below
        * We should wait until kaspa core finally implements vccv2, taking them ages
        */
-
       if (
         await useDBStore.getState().repositories.doesKasiaEventExistsById(txId)
       ) {
@@ -119,27 +121,39 @@ export class BlockProcessorService extends EventEmitter<{
         const unlockedWallet = useWalletStore.getState().unlockedWallet;
         const repositories = useDBStore.getState().repositories;
         if (unlockedWallet && repositories) {
-          const messageId = `${unlockedWallet.id}_${txId}`;
+          const eventId = `${unlockedWallet.id}_${txId}`;
           try {
-            const existingMessage =
-              await repositories.messageRepository.getMessage(messageId);
-            if (existingMessage.status === "pending") {
+            // try message first, fallback to payment
+            let existingEvent;
+            switch (messageType) {
+              case "comm":
+                existingEvent =
+                  await repositories.messageRepository.getMessage(eventId);
+                break;
+              case "payment":
+                existingEvent =
+                  await repositories.paymentRepository.getPayment(eventId);
+                break;
+              default:
+                console.error(`Unknown message type: ${messageType}`);
+                return;
+            }
+            if (existingEvent?.status === "pending") {
               await useMessagingStore
                 .getState()
-                .updateMessageStatus(
+                .updateEventStatus(
                   txId,
                   "confirmed",
                   repositories,
-                  existingMessage
+                  existingEvent
                 );
             }
-          } catch {
-            console.log("Error updating direct status to 'confirmed'");
+          } catch (e) {
+            console.log("Error updating direct status to 'confirmed':", e);
           }
         }
         return;
       }
-      //TO DO: Payments as well
       /*
        * Temp hacky solution to mark out pending broadcasts as confirmed
        * This is planned to be unified with a single pending set so we can extend
@@ -166,10 +180,6 @@ export class BlockProcessorService extends EventEmitter<{
       // try to resolve sender
       const resolvedSenderData = await this.saars.askResolution(txId);
       const resolvedSenderAddress = resolvedSenderData.sender.toString();
-
-      const parsed = parseKaspaMessagePayload(tx.payload);
-
-      const messageType = parsed.type;
       const targetAlias = parsed.alias;
 
       const isCommForUs =

--- a/src/service/block-processor-service.ts
+++ b/src/service/block-processor-service.ts
@@ -2,6 +2,7 @@ import { IBlockAdded, ITransaction, RpcClient } from "kaspa-wasm";
 import { BlockAddedData, Header } from "../types/all";
 import { SenderAndAcceptanceResolutionService } from "./sender-and-acceptance-resolution-service";
 import { useMessagingStore } from "../store/messaging.store";
+import { useWalletStore } from "../store/wallet.store";
 import {
   isKasiaTransaction,
   ParsedKaspaMessagePayload,
@@ -104,13 +105,41 @@ export class BlockProcessorService extends EventEmitter<{
       // mark as processed optimistically
       this.processedTransactionIds.add(txId);
 
+      /*
+       * Temp hacky solution to mark out pending messages as confirmed
+       * This is planned to be unified with a single pending set so we can
+       * align with broadcast message update below
+       * We should wait until kaspa core finally implements vccv2, taking them ages
+       */
+
       if (
         await useDBStore.getState().repositories.doesKasiaEventExistsById(txId)
       ) {
-        console.log(`Transaction ${txId} already processed`);
+        // try to flip pending direct message to confirmed (even if already stored)
+        const unlockedWallet = useWalletStore.getState().unlockedWallet;
+        const repositories = useDBStore.getState().repositories;
+        if (unlockedWallet && repositories) {
+          const messageId = `${unlockedWallet.id}_${txId}`;
+          try {
+            const existingMessage =
+              await repositories.messageRepository.getMessage(messageId);
+            if (existingMessage.status === "pending") {
+              await useMessagingStore
+                .getState()
+                .updateMessageStatus(
+                  txId,
+                  "confirmed",
+                  repositories,
+                  existingMessage
+                );
+            }
+          } catch {
+            console.log("Error updating direct status to 'confirmed'");
+          }
+        }
         return;
       }
-
+      //TO DO: Payments as well
       /*
        * Temp hacky solution to mark out pending broadcasts as confirmed
        * This is planned to be unified with a single pending set so we can extend

--- a/src/service/block-processor-service.ts
+++ b/src/service/block-processor-service.ts
@@ -109,9 +109,8 @@ export class BlockProcessorService extends EventEmitter<{
       const messageType = parsed.type;
 
       /*
-       * Temp hacky solution to mark out pending messages as confirmed
-       * This is planned to be unified with a single pending set so we can
-       * align with broadcast message update below
+       * Temp solution to mark out pending messages and payments as confirmed
+       * This is planned to be refactored once there are some node updates
        * We should wait until kaspa core finally implements vccv2, taking them ages
        */
       if (
@@ -123,7 +122,6 @@ export class BlockProcessorService extends EventEmitter<{
         if (unlockedWallet && repositories) {
           const eventId = `${unlockedWallet.id}_${txId}`;
           try {
-            // try message first, fallback to payment
             let existingEvent;
             switch (messageType) {
               case "comm":
@@ -156,8 +154,7 @@ export class BlockProcessorService extends EventEmitter<{
       }
       /*
        * Temp hacky solution to mark out pending broadcasts as confirmed
-       * This is planned to be unified with a single pending set so we can extend
-       * the same functionality to outgoing chat messages too
+       * Currently only updates in memory broadcasts
        */
       const broadcastStore = useBroadcastStore.getState();
       const existingPendingMessage = broadcastStore.findMessageByTxId(txId);

--- a/src/store/broadcast.store.ts
+++ b/src/store/broadcast.store.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { TransactionStatus } from "../types/all";
 import { useDBStore } from "./db.store";
 import { BroadcastChannel } from "./repository/broadcast-channel.repository";
 import { v4 } from "uuid";
@@ -12,7 +13,7 @@ export type BroadcastMessage = {
   content: string;
   timestamp: Date;
   transactionId: string | null;
-  status: "pending" | "confirmed" | "failed";
+  status: TransactionStatus;
 };
 
 // Add normalization utility at the top level

--- a/src/store/db.store.ts
+++ b/src/store/db.store.ts
@@ -1,16 +1,6 @@
 import { create } from "zustand";
 import { KasiaDB, openDatabase, Repositories } from "./repository/db";
 import { UnlockedWallet } from "../types/wallet.type";
-import { v4 } from "uuid";
-import {
-  LEGACY_STORAGE_KEY,
-  loadLegacyMessages,
-} from "../service/storage-encryption";
-import { PROTOCOL } from "../config/protocol";
-import { FileData, Message } from "./repository/message.repository";
-import { Handshake } from "./repository/handshake.repository";
-import { Payment } from "./repository/payment.repository";
-import { LegacyMessage } from "../types/legacy";
 
 interface DBState {
   db: KasiaDB | undefined;

--- a/src/store/messaging.store.ts
+++ b/src/store/messaging.store.ts
@@ -127,11 +127,11 @@ interface MessagingState {
   hydrateOneonOneConversations: () => Promise<void>;
 
   // Message status management
-  updateMessageStatus: (
+  updateEventStatus: (
     transactionId: string,
     status: "pending" | "confirmed" | "failed",
     repositories: Repositories,
-    existingMessage: Message
+    existingMessage: Message | Payment
   ) => Promise<void>;
 }
 
@@ -805,6 +805,7 @@ export const useMessagingStore = create<MessagingState>((set, g) => {
               tenantId: unlockedWallet.id,
               transactionId: transaction.transactionId,
               fee: transaction.fee,
+              status: "pending",
             };
 
             await repositories.paymentRepository.savePayment(payment);
@@ -1491,23 +1492,31 @@ export const useMessagingStore = create<MessagingState>((set, g) => {
       return txId;
     },
 
-    updateMessageStatus: async (
+    updateEventStatus: async (
       transactionId,
       status,
       repositories,
-      existingMessage
+      existingEvent
     ) => {
-      if (!repositories || !transactionId || !existingMessage) {
+      if (!repositories || !transactionId || !existingEvent) {
         console.warn("Message status update failure: missing props");
         return;
       }
-
       try {
-        // update status in db
-        await repositories.messageRepository.saveMessage({
-          ...existingMessage,
-          status,
-        });
+        switch (existingEvent.__type) {
+          case "message":
+            await repositories.messageRepository.saveMessage({
+              ...existingEvent,
+              status,
+            });
+            break;
+          case "payment":
+            await repositories.paymentRepository.savePayment({
+              ...existingEvent,
+              status,
+            });
+            break;
+        }
 
         // update in-memory state
         set((state) => {
@@ -1516,7 +1525,7 @@ export const useMessagingStore = create<MessagingState>((set, g) => {
               ...oooc,
               events: oooc.events.map((event) => {
                 if (
-                  event.__type === "message" &&
+                  event.__type === existingEvent.__type &&
                   event.transactionId === transactionId
                 ) {
                   return { ...event, status };

--- a/src/store/messaging.store.ts
+++ b/src/store/messaging.store.ts
@@ -794,6 +794,7 @@ export const useMessagingStore = create<MessagingState>((set, g) => {
                 paymentContent = "";
               }
             }
+            const paymentStatus = isFromMe ? "pending" : "confirmed";
             const payment: Payment = {
               __type: "payment",
               amount: transaction.amount,
@@ -806,7 +807,7 @@ export const useMessagingStore = create<MessagingState>((set, g) => {
               tenantId: unlockedWallet.id,
               transactionId: transaction.transactionId,
               fee: transaction.fee,
-              status: "pending",
+              status: paymentStatus,
             };
 
             await repositories.paymentRepository.savePayment(payment);

--- a/src/store/messaging.store.ts
+++ b/src/store/messaging.store.ts
@@ -3,6 +3,7 @@ import {
   KasiaConversationEvent,
   KasiaTransaction,
   OneOnOneConversation,
+  TransactionStatus,
 } from "../types/all";
 import { Contact } from "./repository/contact.repository";
 import {
@@ -129,7 +130,7 @@ interface MessagingState {
   // Message status management
   updateEventStatus: (
     transactionId: string,
-    status: "pending" | "confirmed" | "failed",
+    status: TransactionStatus,
     repositories: Repositories,
     existingMessage: Message | Payment
   ) => Promise<void>;

--- a/src/store/messaging.store.ts
+++ b/src/store/messaging.store.ts
@@ -125,6 +125,14 @@ interface MessagingState {
 
   // Hydration
   hydrateOneonOneConversations: () => Promise<void>;
+
+  // Message status management
+  updateMessageStatus: (
+    transactionId: string,
+    status: "pending" | "confirmed" | "failed",
+    repositories: Repositories,
+    existingMessage: Message
+  ) => Promise<void>;
 }
 
 export const useMessagingStore = create<MessagingState>((set, g) => {
@@ -821,6 +829,8 @@ export const useMessagingStore = create<MessagingState>((set, g) => {
               transaction.content.indexOf(":") + 1
             );
 
+            const isFromMeMessage =
+              transaction.senderAddress === address.toString();
             const message: Message = {
               __type: "message",
               amount: transaction.amount,
@@ -828,11 +838,13 @@ export const useMessagingStore = create<MessagingState>((set, g) => {
               conversationId: existingConversationWithContact.conversation.id,
               content: decryptedContent ?? "",
               createdAt: transaction.createdAt,
-              fromMe: transaction.senderAddress === address.toString(),
+              fromMe: isFromMeMessage,
               id: `${unlockedWallet.id}_${transaction.transactionId}`,
               tenantId: unlockedWallet.id,
               transactionId: transaction.transactionId,
               fee: transaction.fee,
+              // outgoing messages start as pending until confirmed on chain
+              status: isFromMeMessage ? "pending" : "confirmed",
             };
 
             await repositories.messageRepository.saveMessage(message);
@@ -1477,6 +1489,52 @@ export const useMessagingStore = create<MessagingState>((set, g) => {
 
       console.log("self stash created successfully:", txId);
       return txId;
+    },
+
+    updateMessageStatus: async (
+      transactionId,
+      status,
+      repositories,
+      existingMessage
+    ) => {
+      if (!repositories || !transactionId || !existingMessage) {
+        console.warn("Message status update failure: missing props");
+        return;
+      }
+
+      try {
+        // update status in db
+        await repositories.messageRepository.saveMessage({
+          ...existingMessage,
+          status,
+        });
+
+        // update in-memory state
+        set((state) => {
+          const updatedConversations = state.oneOnOneConversations.map(
+            (oooc) => ({
+              ...oooc,
+              events: oooc.events.map((event) => {
+                if (
+                  event.__type === "message" &&
+                  event.transactionId === transactionId
+                ) {
+                  return { ...event, status };
+                }
+                return event;
+              }),
+            })
+          );
+
+          return { oneOnOneConversations: updatedConversations };
+        });
+      } catch (error) {
+        // message might not exist yet (incoming from network) - that's ok
+        console.debug(
+          `Could not update message status for ${transactionId}:`,
+          error
+        );
+      }
     },
   };
 });

--- a/src/store/repository/db.ts
+++ b/src/store/repository/db.ts
@@ -23,7 +23,7 @@ import {
 } from "./broadcast-channel.repository";
 import { MetaRespository } from "./meta.repository";
 
-const CURRENT_DB_VERSION = 3;
+const CURRENT_DB_VERSION = 4;
 
 export class DBNotFoundException extends Error {
   constructor() {
@@ -117,7 +117,7 @@ export type KasiaDB = IDBPDatabase<KasiaDBSchema>;
 
 export const openDatabase = async (): Promise<KasiaDB> => {
   return openDB<KasiaDBSchema>("kasia-db", CURRENT_DB_VERSION, {
-    upgrade(db, oldVersion, newVersion, transaction) {
+    async upgrade(db, oldVersion, newVersion, transaction) {
       console.log(
         `[DB] - Identity database upgrade from version ${oldVersion} to ${newVersion}`
       );
@@ -260,9 +260,25 @@ export const openDatabase = async (): Promise<KasiaDB> => {
       }
 
       if (oldVersion <= 3) {
+        // Migration to v4: Add status field to existing messages
+        const messagesStore = transaction.objectStore("messages");
+        let cursor = await messagesStore.openCursor();
+
+        while (cursor) {
+          const message = cursor.value;
+          // add default status to existing messages that don't have it
+          if (!message.status) {
+            message.status = "confirmed";
+            await cursor.update(message);
+          }
+          cursor = await cursor.continue();
+        }
+
+        console.log("[DB] - Migrated to v4: Added status field to messages");
+      }
+      if (oldVersion <= 4) {
         // HERE next migration, first increase CURRENT_DB_VERSION then implement with oldVersion <= CURRENT_DB_VERSION - 1
         // add more if branching for each next version
-        // BROADCAST CHANNELS
       }
     },
   });

--- a/src/store/repository/db.ts
+++ b/src/store/repository/db.ts
@@ -260,7 +260,7 @@ export const openDatabase = async (): Promise<KasiaDB> => {
       }
 
       if (oldVersion <= 3) {
-        // Migration to v4: Add status field to existing messages
+        // Migration to v4: Add status field to existing messages and payments
         const messagesStore = transaction.objectStore("messages");
         let cursor = await messagesStore.openCursor();
 
@@ -274,7 +274,22 @@ export const openDatabase = async (): Promise<KasiaDB> => {
           cursor = await cursor.continue();
         }
 
-        console.log("[DB] - Migrated to v4: Added status field to messages");
+        const paymentsStore = transaction.objectStore("payments");
+        let paymentCursor = await paymentsStore.openCursor();
+
+        while (paymentCursor) {
+          const payment = paymentCursor.value;
+          // add default status to existing payments that don't have it
+          if (!payment.status) {
+            payment.status = "confirmed";
+            await paymentCursor.update(payment);
+          }
+          paymentCursor = await paymentCursor.continue();
+        }
+
+        console.log(
+          "[DB] - Migrated to v4: Added status field to messages and payments"
+        );
       }
       if (oldVersion <= 4) {
         // HERE next migration, first increase CURRENT_DB_VERSION then implement with oldVersion <= CURRENT_DB_VERSION - 1

--- a/src/store/repository/message.repository.ts
+++ b/src/store/repository/message.repository.ts
@@ -1,5 +1,6 @@
 import { encryptXChaCha20Poly1305, decryptXChaCha20Poly1305 } from "kaspa-wasm";
 import { TransactionId } from "../../types/transactions";
+import { TransactionStatus } from "../../types/all";
 import { DBNotFoundException, KasiaDB } from "./db";
 
 export type DbMessage = {
@@ -15,7 +16,7 @@ export type DbMessage = {
   createdAt: Date;
   transactionId: TransactionId;
   contactId: string;
-  status: "pending" | "confirmed" | "failed";
+  status: TransactionStatus;
   /**
    * encrypted data shaped as `json(MessageBag)`
    */

--- a/src/store/repository/message.repository.ts
+++ b/src/store/repository/message.repository.ts
@@ -15,6 +15,7 @@ export type DbMessage = {
   createdAt: Date;
   transactionId: TransactionId;
   contactId: string;
+  status: "pending" | "confirmed" | "failed";
   /**
    * encrypted data shaped as `json(MessageBag)`
    */
@@ -191,6 +192,7 @@ export class MessageRepository {
       conversationId: message.conversationId,
       createdAt: message.createdAt,
       contactId: message.contactId,
+      status: message.status,
       encryptedData: encryptXChaCha20Poly1305(
         JSON.stringify({
           fileData: message.fileData,
@@ -217,6 +219,7 @@ export class MessageRepository {
       conversationId: dbMessage.conversationId,
       createdAt: dbMessage.createdAt,
       transactionId: dbMessage.transactionId,
+      status: dbMessage.status,
       fee: messageBag.fee,
       fileData: messageBag.fileData,
       amount: messageBag.amount,

--- a/src/store/repository/payment.repository.ts
+++ b/src/store/repository/payment.repository.ts
@@ -1,5 +1,6 @@
 import { encryptXChaCha20Poly1305, decryptXChaCha20Poly1305 } from "kaspa-wasm";
 import { TransactionId } from "../../types/transactions";
+import { TransactionStatus } from "../../types/all";
 import { KasiaDB, DBNotFoundException } from "./db";
 
 export type DbPayment = {
@@ -15,7 +16,7 @@ export type DbPayment = {
   createdAt: Date;
   transactionId: TransactionId;
   contactId: string;
-  status: "pending" | "confirmed" | "failed";
+  status: TransactionStatus;
   /**
    * encrypted data shaped as `json(PaymentBag)`
    */

--- a/src/store/repository/payment.repository.ts
+++ b/src/store/repository/payment.repository.ts
@@ -15,6 +15,7 @@ export type DbPayment = {
   createdAt: Date;
   transactionId: TransactionId;
   contactId: string;
+  status: "pending" | "confirmed" | "failed";
   /**
    * encrypted data shaped as `json(PaymentBag)`
    */
@@ -180,6 +181,7 @@ export class PaymentRepository {
       conversationId: payment.conversationId,
       createdAt: payment.createdAt,
       contactId: payment.contactId,
+      status: payment.status,
       encryptedData: encryptXChaCha20Poly1305(
         JSON.stringify({
           amount: payment.amount,
@@ -204,6 +206,7 @@ export class PaymentRepository {
       contactId: dbPayment.contactId,
       conversationId: dbPayment.conversationId,
       createdAt: dbPayment.createdAt,
+      status: dbPayment.status,
       transactionId: dbPayment.transactionId,
       fee: paymentBag.fee,
       amount: paymentBag.amount,

--- a/src/types/all.ts
+++ b/src/types/all.ts
@@ -163,3 +163,5 @@ export type OneOnOneConversation = {
 export type KasiaConversationEvent = Message | Payment | Handshake;
 
 export type ConnectionMode = "manual" | "auto";
+
+export type TransactionStatus = "pending" | "confirmed" | "failed";

--- a/src/utils/message-payload.ts
+++ b/src/utils/message-payload.ts
@@ -1,7 +1,6 @@
 import { PROTOCOL } from "../config/protocol";
 import { hexToString } from "./format";
 import { ITransaction } from "wasm/kaspa";
-import { ExplorerTransaction } from "../types/transactions";
 
 export type ParsedKaspaMessagePayload = {
   type: string;


### PR DESCRIPTION
## what?
adds 'pending, active, failed' message status to direct messages and payments.
follows the current broadcast approach.

handshakes have _not_ been done as they are a little more complicated.

followup tasks from this:
- add custom fees to 'payments' (custom fees should exist for wallet withdrawals and handshakes as well, but payments should have some urgency due to its UX)
- extend status into handshakes
- add rbf for pending tx
- refactor message ingestion once vccv2 is out in the real world