### PR TITLE
refactor: wallet storage service

### DIFF
--- a/src/service/account-service.ts
+++ b/src/service/account-service.ts
@@ -8,7 +8,7 @@ import {
   GeneratorSummary,
   sompiToKaspaString,
   kaspaToSompi,
-  PrivateKeyGenerator,
+  PrivateKey,
   Generator,
   RpcClient,
 } from "kaspa-wasm";
@@ -309,21 +309,15 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
     generator: Generator,
     postTransactionCallback?: () => Promise<void>
   ): Promise<string> {
-    const privateKeyGenerator = WalletStorageService.getPrivateKeyGenerator(
-      this.unlockedWallet,
-      this.pwd
-    );
+    const privateKey = WalletStorageService.getPrivateKey(this.unlockedWallet);
 
-    if (!privateKeyGenerator) {
-      throw new Error("Failed to generate private key");
+    if (!privateKey) {
+      throw new Error("Failed to get private key");
     }
 
     let pending: PendingTransaction | null;
     while ((pending = await generator.next())) {
-      const txid = await this.signAndSubmitTransaction(
-        pending,
-        privateKeyGenerator
-      );
+      const txid = await this.signAndSubmitTransaction(pending, privateKey);
       if (postTransactionCallback) {
         await postTransactionCallback();
       }
@@ -334,7 +328,7 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
 
   private async signAndSubmitTransaction(
     pendingTransaction: PendingTransaction,
-    privateKeyGenerator: PrivateKeyGenerator
+    privateKey: PrivateKey
   ): Promise<string> {
     // Validate transaction fee (to make sure its not super high!) before proceeding
     this.validateTransactionFee(pendingTransaction.feeAmount);
@@ -348,14 +342,10 @@ export class AccountService extends EventEmitter<AccountServiceEvents> {
       console.log(`  Address ${i + 1}: ${addr.toString()}`);
     });
 
-    // Always use receive key for all addresses since we only use primary address
+    // use the same private key for all inputs (single address wallet)
     const privateKeys = pendingTransaction.addresses().map(() => {
       console.log("Using primary address key for signing");
-      const key = privateKeyGenerator.receiveKey(0);
-      if (!key) {
-        throw new Error("Failed to generate private key for signing");
-      }
-      return key;
+      return privateKey;
     });
 
     // Sign the transaction

--- a/src/service/wallet-storage-service.ts
+++ b/src/service/wallet-storage-service.ts
@@ -2,8 +2,8 @@ import {
   decryptXChaCha20Poly1305,
   encryptXChaCha20Poly1305,
   Mnemonic,
+  PrivateKey,
   PrivateKeyGenerator,
-  PublicKeyGenerator,
   XPrv,
 } from "kaspa-wasm";
 import { v4 as uuidv4 } from "uuid";
@@ -19,18 +19,18 @@ export class WalletStorageService {
     }
   }
 
-  static getPrivateKeyGenerator(
-    wallet: Pick<UnlockedWallet, "encryptedXPrv">,
-    password: string
-  ): PrivateKeyGenerator {
+  static getPrivateKey(
+    wallet: Pick<UnlockedWallet, "encryptedPrivateKey" | "password">
+  ): PrivateKey {
     try {
-      // First decrypt the mnemonic phrase
-      const seed = decryptXChaCha20Poly1305(wallet.encryptedXPrv, password);
-      const xprv = new XPrv(seed);
-
-      return new PrivateKeyGenerator(xprv, false, BigInt(0));
+      // decrypt the private key hex string
+      const privateKeyHex = decryptXChaCha20Poly1305(
+        wallet.encryptedPrivateKey,
+        wallet.password
+      );
+      return new PrivateKey(privateKeyHex);
     } catch (error) {
-      console.error("Error getting private key generator:", error);
+      console.error("Error getting private key:", error);
       throw new Error("Invalid password");
     }
   }
@@ -78,27 +78,30 @@ export class WalletStorageService {
         );
       }
 
-      // Generate the seed with passphrase and extended private key
+      // Generate the seed with passphrase and create master extended private key
       const seed = mnemonic.toSeed(passphrase);
-      const extendedKey = new XPrv(seed);
+      const masterXPrv = new XPrv(seed);
 
-      const publicKeyGenerator = PublicKeyGenerator.fromMasterXPrv(
-        extendedKey,
+      // get the receive private key for address 0
+      const receivePrivateKey = new PrivateKeyGenerator(
+        masterXPrv,
         false,
         BigInt(0)
+      ).receiveKey(0);
+
+      const receivePublicKey = receivePrivateKey.toPublicKey();
+
+      // encrypt the private key hex string
+      const encryptedPrivateKey = encryptXChaCha20Poly1305(
+        receivePrivateKey.toString(),
+        password
       );
 
-      const encryptedXPrv = encryptXChaCha20Poly1305(seed, password);
-
-      const receivePublicKey = publicKeyGenerator.receivePubkey(0);
-
-      // Create the unlocked wallet with the encrypted seed
       return {
         id: wallet.id,
         name: wallet.name,
         activeAccount: 1,
-        encryptedXPrv: encryptedXPrv,
-        publicKeyGenerator,
+        encryptedPrivateKey,
         password,
         receivePublicKey,
         passphrase: passphrase || undefined,
@@ -144,7 +147,7 @@ export class WalletStorageService {
     const updatedWallets = wallets.filter((w) => w.id !== walletId);
     localStorage.setItem(this._storageKey, JSON.stringify(updatedWallets));
 
-    // clean up messaging-related localStorage keys
+    // clean-up messaging-related localStorage keys
     localStorage.removeItem(`kasia_last_opened_contact_${walletId}`);
     localStorage.removeItem(`kasia_last_opened_channel_${walletId}`);
     localStorage.removeItem(`metadata_${walletId}`);

--- a/src/store/messaging.store.ts
+++ b/src/store/messaging.store.ts
@@ -149,12 +149,8 @@ export const useMessagingStore = create<MessagingState>((set, g) => {
       const unlockedWallet = useWalletStore.getState().unlockedWallet;
       if (!unlockedWallet) return;
 
-      const privateKeyString = WalletStorageService.getPrivateKeyGenerator(
-        unlockedWallet,
-        unlockedWallet.password
-      )
-        .receiveKey(0)
-        .toString();
+      const privateKeyString =
+        WalletStorageService.getPrivateKey(unlockedWallet).toString();
 
       const aliasesToFetch = new Set<string>(aliases);
       if (!aliasesToFetch.size && oooc.conversation.theirAlias) {
@@ -483,11 +479,7 @@ export const useMessagingStore = create<MessagingState>((set, g) => {
       }
 
       // cannot use `walletStore.address` because it is not always already populated
-      const address = WalletStorageService.getPrivateKeyGenerator(
-        unlockedWallet,
-        unlockedWallet.password
-      )
-        .receiveKey(0)
+      const address = WalletStorageService.getPrivateKey(unlockedWallet)
         .toAddress(useWalletStore.getState().selectedNetwork)
         .toString();
 
@@ -928,8 +920,8 @@ export const useMessagingStore = create<MessagingState>((set, g) => {
 
       const network = useNetworkStore.getState().network;
 
-      const receiveAddress = unlockedWallet.publicKeyGenerator
-        .receiveAddress(network, 0)
+      const receiveAddress = unlockedWallet.receivePublicKey
+        .toAddress(network)
         .toString();
 
       // 1. Clear last opened contact for this wallet
@@ -1363,12 +1355,7 @@ export const useMessagingStore = create<MessagingState>((set, g) => {
         );
       }
 
-      const privateKeyGenerator = WalletStorageService.getPrivateKeyGenerator(
-        unlockedWallet,
-        unlockedWallet.password
-      );
-
-      const privateKey = privateKeyGenerator.receiveKey(0);
+      const privateKey = WalletStorageService.getPrivateKey(unlockedWallet);
 
       const decryptedContent = decrypt_message(
         new EncryptedMessage(tx.parsedPayload.encryptedHex),
@@ -1437,11 +1424,9 @@ export const useMessagingStore = create<MessagingState>((set, g) => {
       }
 
       // get our own address for encryption and transaction
-      const address = WalletStorageService.getPrivateKeyGenerator(
-        walletStore.unlockedWallet,
-        walletStore.unlockedWallet.password
+      const address = WalletStorageService.getPrivateKey(
+        walletStore.unlockedWallet
       )
-        .receiveKey(0)
         .toAddress(walletStore.selectedNetwork)
         .toString();
 

--- a/src/types/wallet.type.ts
+++ b/src/types/wallet.type.ts
@@ -1,4 +1,4 @@
-import { PublicKey, PublicKeyGenerator } from "wasm/kaspa";
+import { PublicKey } from "wasm/kaspa";
 
 export type Wallet = {
   id: string;
@@ -10,8 +10,7 @@ export type UnlockedWallet = {
   id: string;
   name: string;
   activeAccount: 1;
-  publicKeyGenerator: PublicKeyGenerator;
-  encryptedXPrv: string;
+  encryptedPrivateKey: string;
   password: string;
   receivePublicKey: PublicKey;
   passphrase?: string;

--- a/src/utils/historical-loader.ts
+++ b/src/utils/historical-loader.ts
@@ -41,12 +41,8 @@ export const historicalLoader_loadSendAndReceivedHandshake = async (
   if (!unlockedWallet) {
     throw new Error("Wallet not unlocked");
   }
-  const privateKeyString = WalletStorageService.getPrivateKeyGenerator(
-    unlockedWallet,
-    unlockedWallet.password
-  )
-    .receiveKey(0)
-    .toString();
+  const privateKeyString =
+    WalletStorageService.getPrivateKey(unlockedWallet).toString();
 
   const ooocs = currentOneOnOneConversations;
   const ooocsByAddress: Map<string, OneOnOneConversation> = new Map();


### PR DESCRIPTION
## what?
refactors how we generate and handle public and private keys.
there was some incorrect terminology in the wallet-storage-service. (e.g. calling `encryptedXPrv` when it was in fact the seed). This lead me to have a look and refactor some things for clarity.

- removes the public key generator, stops assigning the wallets seed against the wallet object
- replaces the above with the derived private key at index 0(we still obviously keep the mnemonic in storage)
- I've also reduced the props that were being passed to our privatekey return

note: this works well under the assumption we only use one address / key set. at the moment this is the current state of things.
I don't believe this change will make any future work more difficult.

## testing
everything should work as is. nothing changes. no migrations needed.