### PR TITLE
feat: add testnet-12 support

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,4 +1,4 @@
-# mainnet or testnet-10
+# mainnet, testnet-10 or testnet-12
 VITE_DEFAULT_KASPA_NETWORK=mainnet
 VITE_ALLOWED_KASPA_NETWORKS=mainnet
 VITE_DISABLE_PASSWORD_REQUIREMENTS=false

--- a/.env.staging
+++ b/.env.staging
@@ -1,6 +1,6 @@
 # mainnet or testnet-10
-VITE_DEFAULT_KASPA_NETWORK=testnet-10
-VITE_ALLOWED_KASPA_NETWORKS=mainnet,testnet-10
+VITE_DEFAULT_KASPA_NETWORK=testnet-12
+VITE_ALLOWED_KASPA_NETWORKS=mainnet,testnet-10,testnet-12
 VITE_DISABLE_PASSWORD_REQUIREMENTS=false
 # info, warn, error, silent
 VITE_LOG_LEVEL=info

--- a/README.md
+++ b/README.md
@@ -77,9 +77,9 @@ npm run dev
 You can also configure environment variables by copying the `.env.dist` file to `.env` and modifying the variables as needed. Here are some example configurations:
 
 ```bash
-# mainnet or testnet-10
+# mainnet, testnet-10 or testnet-12
 VITE_DEFAULT_KASPA_NETWORK=mainnet
-VITE_ALLOWED_KASPA_NETWORKS=mainnet,testnet-10
+VITE_ALLOWED_KASPA_NETWORKS=mainnet,testnet-10,testnet-12
 VITE_DISABLE_PASSWORD_REQUIREMENTS=true
 # info, warn, error, silent
 VITE_LOG_LEVEL=info
@@ -88,6 +88,9 @@ VITE_LOG_LEVEL=info
 VITE_INDEXER_MAINNET_URL=
 VITE_INDEXER_TESTNET_URL=
 ```
+
+### Testnet-12
+Note: Running testnet-12 will require downloading the wasm-sdk from a build artifact. If this is something you want to do - contact on discord for help.
 
 ## Historical Messages
 For UX purposes, Kasia team built [Kasia Indexer](https://github.com/K-Kluster/kasia-indexer), while not required, it offers cross-device synchronization capabilities. In short, it scans the Kaspa network continuously and store the Kasia protocol messages.

--- a/src/service/integrations/kns-integration-service.ts
+++ b/src/service/integrations/kns-integration-service.ts
@@ -4,6 +4,7 @@ import { NetworkType } from "../../types/all";
 const knsApiRoots = {
   mainnet: "https://api.knsdomains.org/mainnet/api/v1",
   "testnet-10": "https://api.knsdomains.org/tn10/api/v1",
+  "testnet-12": "https://api.knsdomains.org/tn12/api/v1", //this wont work but its ok
 };
 
 export interface KNSDomainResolution {
@@ -23,7 +24,11 @@ export const knsIntegrationService_getDomainResolution = async (
   network: NetworkType,
   name: string
 ): Promise<KNSDomainResolution | null> => {
-  if (network !== "mainnet" && network !== "testnet-10") {
+  if (
+    network !== "mainnet" &&
+    network !== "testnet-10" &&
+    network !== "testnet-12"
+  ) {
     throw new Error("Unsupported network");
   }
 

--- a/src/types/all.ts
+++ b/src/types/all.ts
@@ -6,7 +6,7 @@ import { Handshake } from "../store/repository/handshake.repository";
 import { Payment } from "../store/repository/payment.repository";
 import { TransactionId } from "./transactions";
 
-export type NetworkType = "mainnet" | "testnet-10" | "testnet-11" | "devnet";
+export type NetworkType = "mainnet" | "testnet-10" | "testnet-12" | "devnet";
 
 export interface BlockAddedData {
   type: string;

--- a/src/utils/explorer-url.ts
+++ b/src/utils/explorer-url.ts
@@ -8,8 +8,8 @@ export const getExplorerUrl = (txId: string, network: string) => {
       return `https://explorer.kaspa.org/txs/${txId}`;
     case "testnet-10":
       return `https://explorer-tn10.kaspa.org/txs/${txId}`;
-    case "testnet-11":
-      return `https://explorer-tn11.kaspa.org/txs/${txId}`;
+    case "testnet-12":
+      return `https://next-explorer.kasia.fyi/txs/${txId}`;
     case "devnet":
       return `https://explorer-devnet.kaspa.org/txs/${txId}`;
     default:

--- a/src/utils/network-display.ts
+++ b/src/utils/network-display.ts
@@ -1,6 +1,7 @@
 export enum KasiaNetwork {
   MAINNET = "mainnet",
   TESTNET_10 = "testnet-10",
+  TESTNET_12 = "testnet-12",
 }
 
 export const getDisplayableNetworkFromNetworkString = (network: string) => {
@@ -10,6 +11,10 @@ export const getDisplayableNetworkFromNetworkString = (network: string) => {
 
   if (network === KasiaNetwork.TESTNET_10) {
     return "Testnet";
+  }
+
+  if (network === KasiaNetwork.TESTNET_12) {
+    return "Cov++ Testnet";
   }
 
   return "Unknown";

--- a/src/utils/network.ts
+++ b/src/utils/network.ts
@@ -21,7 +21,7 @@ export function ensureAddressPrefix(
   }
 
   // Add appropriate prefix based on network
-  if (networkId === "testnet-10" || networkId === "testnet-11") {
+  if (networkId === "testnet-10" || networkId === "testnet-12") {
     return `kaspatest:${address}`;
   } else if (networkId === "mainnet") {
     return `kaspa:${address}`;


### PR DESCRIPTION
## what?
adds tn-12
can manually use node:
`wss://tn12-wrpc.kasia.fyi`

no indexer available

faucet here:
https://faucet-tn12.kaspanet.io/
